### PR TITLE
Handle unknown solvers gracefully

### DIFF
--- a/straindesign/lptools.py
+++ b/straindesign/lptools.py
@@ -80,7 +80,7 @@ def select_solver(solver=None, model=None) -> str:
         if solver in avail_solvers:
             return solver
         else:
-            logging.warning('Selected solver ' + solver + ' not available. Using ' + avail_solvers[0] + " instead.")
+            logging.warning('Selected solver ' + solver + ' not available. Using ' + list(avail_solvers)[0] + " instead.")
     try:
         # if no solver was defined, use solver specified in model
         if hasattr(model, 'solver') and hasattr(model.solver, 'interface'):
@@ -101,7 +101,7 @@ def select_solver(solver=None, model=None) -> str:
         pass
     # if no solver is specified in cobra, fall back to list of available solvers and return the
     # first one available.
-    return avail_solvers[0]
+    return list(avail_solvers)[0]
 
 
 def idx2c(i, prev) -> 'list':

--- a/straindesign/solver_interface.py
+++ b/straindesign/solver_interface.py
@@ -21,7 +21,7 @@
 from numpy import inf, isinf, isnan, unique
 from scipy import sparse
 from typing import List, Tuple
-from straindesign import avail_solvers
+from straindesign import avail_solvers, GLPK
 from straindesign.names import *
 import logging
 
@@ -115,7 +115,7 @@ class MILP_LP(object):
         # Select solver (either by choice or automatically cplex > gurobi > glpk)
         if self.solver is None:
             if len(avail_solvers) > 0:
-                self.solver = avail_solvers[0]
+                self.solver = list(avail_solvers)[0]
             else:
                 raise Exception('No solver available. Please ensure that one of the following '\
                     'solvers is avaialable in your Python environment: CPLEX, Gurobi, SCIP, GLPK')

--- a/straindesign/strainDesignProblem.py
+++ b/straindesign/strainDesignProblem.py
@@ -108,7 +108,7 @@ class SDProblem:
 
         if self.solver is None:
             if len(avail_solvers) > 0:
-                self.solver = avail_solvers[0]
+                self.solver = list(avail_solvers)[0]
             else:
                 raise Exception('No solver available. Please ensure that one of the following '\
                     'solvers is avaialable in your Python environment: CPLEX, Gurobi, SCIP, GLPK')

--- a/tests/test_01_load_models_and_solvers.py
+++ b/tests/test_01_load_models_and_solvers.py
@@ -47,6 +47,10 @@ def test_load_solvers(model_small_example):
     solver1 = sd.select_solver()
     assert (solver1 in [CPLEX, GUROBI, GLPK, SCIP])
 
+    # solver selection with unknown solver specified
+    solver1 = sd.select_solver('notasolver')
+    assert (solver1 in [CPLEX, GUROBI, GLPK, SCIP])
+
     # with solver specified
     solver2 = sd.select_solver('scip')
     assert (solver2 == SCIP)


### PR DESCRIPTION
Hello, this is a tiny fix that I found while playing with this great package.

### Description

Selecting an unknown/uninstalled solver fails at indexing of available solvers. This is because `avail_solvers` is represented as a set, which do not implements `__getitem__`.

Example Traceback from pytest:

```python
       # first try to use selected solver                                                   
        if solver:                                                                           
            if solver in avail_solvers:                                                      
                return solver                                                                
            else:                                                                            
>               logging.warning('Selected solver ' + solver + ' not available. Using ' + avai
l_solvers[0] + " instead.")                                                                  
E               TypeError: 'set' object is not subscriptable                                 
                                                                                             
../.virtualenvs/isofba/lib/python3.9/site-packages/straindesign/lptools.py:83: TypeError
```

### Fix implementation

This PR converts `avail_solvers` into a list previous to the index operation. Additionally, a test was added to check that asking for a non-existing solver selects an existing one properly without raising.

Note that sets are unordered. Usually, you'd get the same solver by converting first to a list; but that is not guaranteed, it may change with the python implementation. Alternatively, one could just raise if the solver is not available.