### PR TITLE
Gene-regulatory correctness under compression + solver numerical-status robustness

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,7 +1,7 @@
 version: 2
 
 build:
-  os: "ubuntu-20.04"
+  os: "ubuntu-lts-latest"
   tools:
     python: "3.10"
     

--- a/straindesign/compression.py
+++ b/straindesign/compression.py
@@ -777,7 +777,7 @@ class _WorkRecord:
         self.stats = CompressionStatistics()
         self.stats.inc_compression_iteration()
 
-    def remove_reactions(self, suppressed: Optional[Set[str]]) -> bool:
+    def remove_reactions(self, suppressed: Set[str]) -> bool:
         """Remove reactions by name - uses batch removal."""
         if not suppressed:
             return False
@@ -927,16 +927,22 @@ class StoichMatrixCompressor:
                  stoich: RationalMatrix,
                  meta_names: List[str],
                  reac_names: List[str],
-                 suppressed: Optional[Set[str]] = None,
-                 bounds: Optional[List[Tuple[float, float]]] = None) -> CompressionRecord:
+                 suppressed: Set[str] = set(),
+                 bounds: Optional[List[Tuple[float, float]]] = None,
+                 protected: Set[str] = set()) -> CompressionRecord:
         """Compress network, return transformation matrices.
 
         Single-pass approach: each iteration computes the nullspace once,
         then removes zero-flux reactions AND merges coupled groups from
         the same kernel.  Re-iterates only when contradicting groups were
         removed (which may expose new couplings).
+
+        `protected` is an optional set of reaction names that must NOT be merged
+        into coupled groups (kept intact). The rest of their coupled group still
+        merges. Unlike `suppressed`, protected reactions are NOT removed.
         """
         work = _WorkRecord(stoich, meta_names, reac_names, bounds)
+        work.protected_names = set(protected)
 
         do_nullspace = CompressionMethod.NULLSPACE in self._methods
         do_recursive = CompressionMethod.RECURSIVE in self._methods
@@ -986,12 +992,17 @@ class StoichMatrixCompressor:
                 work.stats.inc_zero_flux_reactions()
         return zero_flux
 
-    def _find_coupled_groups(self, kernel_pattern, kernel_values, num_reacs):
+    def _find_coupled_groups(self, kernel_pattern, kernel_values, num_reacs, protected_indices=set()):
         """Find groups of coupled reactions from kernel sparsity pattern.
 
         Args:
             kernel_pattern: CSR matrix with 1s at non-zero positions (for indptr/indices)
             kernel_values: {row: {col: Fraction}} for actual values
+            protected_indices: optional set of reaction indices that must NOT be merged
+                into any coupled group (kept as their own reactions). The rest of a
+                coupled group is still merged. Used e.g. to keep gene-controlled
+                reactions intact through compression before GPR extension so that the
+                gene multiplicity is preserved (regulatory/knock-in correctness).
 
         Returns (groups, ratios) where:
         - groups: list of lists, each containing indices of coupled reactions
@@ -1019,7 +1030,7 @@ class StoichMatrixCompressor:
                 continue
 
             for i, reac_a in enumerate(potential):
-                if ratios[reac_a] is not None:
+                if ratios[reac_a] is not None or reac_a in protected_indices:
                     continue
                 group = None
 
@@ -1028,7 +1039,7 @@ class StoichMatrixCompressor:
 
                 for j in range(i + 1, len(potential)):
                     reac_b = potential[j]
-                    if ratios[reac_b] is not None:
+                    if ratios[reac_b] is not None or reac_b in protected_indices:
                         continue
 
                     # Get values for reaction b
@@ -1090,8 +1101,11 @@ class StoichMatrixCompressor:
                     zero_flux.add(reac)
                     work.stats.inc_zero_flux_reactions()
 
-        # Find and merge coupled groups
-        groups, ratios = self._find_coupled_groups(kernel_pattern, kernel_values, work.size.reacs)
+        # Find and merge coupled groups (skipping protected reactions, which must
+        # stay intact through compression — mapped from names to current indices)
+        prot_names = getattr(work, 'protected_names', set())
+        protected_idx = {i for i, n in enumerate(work.reac_names) if n in prot_names} if prot_names else set()
+        groups, ratios = self._find_coupled_groups(kernel_pattern, kernel_values, work.size.reacs, protected_idx)
 
         reactions_to_remove = set(zero_flux)
         contradicting_removed = False
@@ -1280,7 +1294,8 @@ def remove_conservation_relations(model) -> None:
 def compress_cobra_model(model,
                          methods: Optional[List[Union[str, CompressionMethod]]] = None,
                          in_place: bool = True,
-                         suppressed_reactions: Optional[Set[str]] = None) -> CompressionResult:
+                         suppressed_reactions: Set[str] = set(),
+                         protected_reactions: Set[str] = set()) -> CompressionResult:
     """
     Compress a COBRA model using nullspace-based coupling detection.
 
@@ -1322,7 +1337,7 @@ def compress_cobra_model(model,
     # Run compression
     compressor = StoichMatrixCompressor(*compression_methods)
     bounds = [(float(r.lower_bound), float(r.upper_bound)) for r in model.reactions]
-    compression_record = compressor.compress(stoich_matrix, metabolite_names, reaction_names, suppressed_reactions, bounds)
+    compression_record = compressor.compress(stoich_matrix, metabolite_names, reaction_names, suppressed_reactions, bounds, protected_reactions)
 
     # Apply to model (uses direct manipulation, bypasses solver)
     reaction_map = _apply_compression_to_model(model, compression_record, reaction_names)
@@ -1666,7 +1681,8 @@ def _combine_gpr_or(gpr_bodies):
 # =============================================================================
 
 
-def compress_model(model, no_par_compress_reacs=set(), compression_backend='sparse_rref', propagate_gpr=False):
+def compress_model(model, no_par_compress_reacs=set(), compression_backend='sparse_rref', propagate_gpr=False,
+                   no_coupled_compress_reacs=set()):
     """Compress a metabolic model using multiple techniques.
 
     Performs blocked reaction removal, conservation relation removal, and
@@ -1676,6 +1692,11 @@ def compress_model(model, no_par_compress_reacs=set(), compression_backend='spar
     Args:
         model: COBRA model to compress in-place
         no_par_compress_reacs: Reactions exempt from parallel compression
+        no_coupled_compress_reacs: Reactions exempt from coupled compression. The rest of
+            their coupled group still merges. Used to keep gene-controlled reactions
+            un-merged through COMPRESS#1 so that gene multiplicity is preserved exactly once
+            GPR rules are integrated (correct gene-regulatory semantics under compression).
+            To also exempt them from parallel merging, include them in no_par_compress_reacs.
         compression_backend: Compression backend to use:
             - 'sparse_rref' (default): Pure Python sparse integer RREF.
               No external dependencies beyond NumPy/SciPy.
@@ -1691,6 +1712,7 @@ def compress_model(model, no_par_compress_reacs=set(), compression_backend='spar
         list of dict: Compression maps for reversing each compression step
     """
     from straindesign.networktools import suppress_lp_context, _is_lp_suppressed
+    no_coupled_compress_reacs = set(no_coupled_compress_reacs)
     with suppress_lp_context(model):
         cmp_mapReac = []
         use_java = (compression_backend == 'efmtool_rref')
@@ -1730,7 +1752,8 @@ def compress_model(model, no_par_compress_reacs=set(), compression_backend='spar
             numr_pre = len(model.reactions)
             LOG.info(f'  Compression {run}: Lumping coupled reactions.')
             reac_map_exp = compress_model_coupled(model, compression_backend,
-                                                  propagate_gpr=propagate_gpr)
+                                                  propagate_gpr=propagate_gpr,
+                                                  protected_reactions=no_coupled_compress_reacs)
             for new_reac, old_reac_val in reac_map_exp.items():
                 old_reacs = [r for r in no_par_compress_reacs if r in old_reac_val]
                 if old_reacs:
@@ -1759,7 +1782,7 @@ def _remove_conservation_relations_java(model) -> None:
 
 
 def compress_model_coupled(model, compression_backend='sparse_rref', propagate_gpr=False,
-                           suppressed_reactions=None):
+                           suppressed_reactions=set(), protected_reactions=set()):
     """Compress by lumping stoichiometrically coupled (dependent) reactions.
 
     Identifies groups of reactions whose flux vectors are proportional in every
@@ -1777,6 +1800,11 @@ def compress_model_coupled(model, compression_backend='sparse_rref', propagate_g
             design constraints from being deleted by the Java compressor's
             CoupledContradicting logic. Ignored for the Python backend (which
             handles contradicting groups correctly via bounds intersection).
+        protected_reactions: Set of reaction IDs to exempt from coupled merging
+            (kept as their own reactions; the rest of their coupled group still
+            merges). Python (sparse_rref) backend only. Used to keep gene-controlled
+            reactions intact through compression before GPR integration so that the
+            gene multiplicity is preserved (correct gene-regulatory semantics).
 
     Returns:
         dict: Mapping {compressed_id: {orig_id: factor, ...}}
@@ -1800,7 +1828,8 @@ def compress_model_coupled(model, compression_backend='sparse_rref', propagate_g
         for r in model.reactions:
             r.gene_reaction_rule = ''
 
-        result = compress_cobra_model(model, methods=CompressionMethod.standard(), in_place=True)
+        result = compress_cobra_model(model, methods=CompressionMethod.standard(), in_place=True,
+                                      protected_reactions=protected_reactions)
         reaction_map = result.reaction_map
         # Python compressor handles contradicting groups internally via bounds
         # intersection in _handle_coupled_combine (removes zero-flux groups and

--- a/straindesign/compute_strain_designs.py
+++ b/straindesign/compute_strain_designs.py
@@ -326,12 +326,33 @@ def compute_strain_designs(model: Model, **kwargs: dict) -> SDSolutions:
                     if p in [INNER_OBJECTIVE, OUTER_OBJECTIVE, PROD_ID]:
                         for k in param.keys():
                             no_par_compress_reacs.add(k)
+        # Keep reactions controlled by a gene that carries a REGULATORY intervention intact
+        # through COMPRESS#1 (exempt from merging). Otherwise, if a gene controls several
+        # reactions that get merged before GPR integration, the merged reaction is hooked to
+        # the gene with the wrong (collapsed) stoichiometry, so a gene-regulatory bound
+        # (g <= X / g >= X) is mis-scaled vs the uncompressed model. They are merged correctly
+        # in COMPRESS#2 once the g_gene metabolite exists. Gene KOs (=0) and gene KIs
+        # (unbounded when added) are unaffected, so only regulatory genes need protecting.
+        no_coupled_compress_reacs = set()
+        if _deferred_reg:
+            import re as _re
+            _gene_by_id = {g.id: g for g in cmp_model.genes}
+            _gene_by_name = {g.name: g for g in cmp_model.genes if g.name}
+            for _constr in _deferred_reg:
+                for _tok in _re.findall(r'[A-Za-z_][\w]*', _constr):
+                    _g = _gene_by_id.get(_tok) or _gene_by_name.get(_tok)
+                    if _g is not None:
+                        no_coupled_compress_reacs.update(r.id for r in _g.reactions)
+            # also exempt them from parallel merging so their names stay stable across the
+            # compression passes (keeps the coupled-exemption matching them by name)
+            no_par_compress_reacs.update(no_coupled_compress_reacs)
         compression_backend = kwargs.get('compression_backend', 'sparse_rref')
         logging.info('Compressing Network (' + str(len(cmp_model.reactions)) + ' reactions).')
         t0 = time.time()
         cmp_mapReac_1 = compress_model(cmp_model, no_par_compress_reacs,
                                         compression_backend=compression_backend,
-                                        propagate_gpr=True)
+                                        propagate_gpr=True,
+                                        no_coupled_compress_reacs=no_coupled_compress_reacs)
         sd_modules = compress_modules(sd_modules, cmp_mapReac_1)
         # Compress reaction + regulatory costs only (gene costs not yet added)
         cmp_ko_cost, cmp_ki_cost, cmp_mapReac_1 = compress_ki_ko_cost(

--- a/straindesign/cplex_interface.py
+++ b/straindesign/cplex_interface.py
@@ -205,6 +205,13 @@ class Cplex_MILP_LP(Cplex):
                 min_cx = -inf
                 status = UNBOUNDED
                 return x, min_cx, status
+            elif status in [5, 6]:  # optimal/best with unscaled infeasibilities (numerical trouble)
+                # Ill-conditioned MILPs (e.g. large MCS/Farkas problems) can return a usable
+                # solution flagged with numerical caveats. Accept it with a warning instead of crashing.
+                logging.warning('CPLEX returned a solution with unscaled infeasibilities (numerical '
+                                'difficulties); using it (not guaranteed exact). Consider tightening bounds.')
+                min_cx = self.solution.get_objective_value()
+                status = TIME_LIMIT_W_SOL
             else:
                 logging.exception(status)
                 logging.exception(self.solution.get_status_string())
@@ -239,6 +246,8 @@ class Cplex_MILP_LP(Cplex):
                 opt = -inf
             elif status in [3, 103, 108]:  # infeasible (LP: 3, MIP: 103/108)
                 opt = nan
+            elif status in [5, 6]:  # optimal/best with unscaled infeasibilities (numerical)
+                opt = self.solution.get_objective_value()
             else:
                 logging.exception(status)
                 logging.exception(self.solution.get_status_string())

--- a/straindesign/efmtool_cmp_interface.py
+++ b/straindesign/efmtool_cmp_interface.py
@@ -364,7 +364,7 @@ def basic_columns_rat_java(mx, tolerance=0):
     return col_map[0:rank]
 
 
-def compress_model_java(model, suppressed_reactions=None):
+def compress_model_java(model, suppressed_reactions=set()):
     """Legacy Java compression using jpype (requires jpype and sympy).
 
     Args:

--- a/straindesign/gurobi_interface.py
+++ b/straindesign/gurobi_interface.py
@@ -216,6 +216,30 @@ class Gurobi_MILP_LP(gp.Model):
                 min_cx = -inf
                 status = UNBOUNDED
                 return x, min_cx, status
+        elif status == gstatus.NUMERIC:
+            # Numerical trouble (e.g. ill-conditioned large MCS/Farkas MILPs). Retry once
+            # with maximum numerical focus, then fall back to the best incumbent (if any)
+            # or report no usable solution instead of crashing.
+            prev_nf = self.params.NumericFocus
+            self.params.NumericFocus = 3
+            self.optimize()
+            self.params.NumericFocus = prev_nf
+            status = self.Status
+            if status in [gstatus.OPTIMAL, gstatus.SOLUTION_LIMIT, gstatus.SUBOPTIMAL, gstatus.USER_OBJ_LIMIT]:
+                min_cx = self.ObjVal
+                status = OPTIMAL
+            elif self.SolCount > 0:
+                logging.warning('Gurobi reported numerical difficulties; using best incumbent solution '
+                                '(not guaranteed optimal).')
+                min_cx = self.ObjVal
+                status = TIME_LIMIT_W_SOL
+            else:
+                logging.warning('Gurobi reported numerical difficulties and found no usable solution; '
+                                'treating as no solution.')
+                x = [nan] * self.NumVars
+                min_cx = nan
+                status = TIME_LIMIT
+                return x, min_cx, status
         else:
             raise Exception('Status code ' + str(status) + " not yet handeld.")
         x = self.getSolution()
@@ -241,6 +265,9 @@ class Gurobi_MILP_LP(gp.Model):
             opt = -inf
         elif status in [gstatus.INFEASIBLE, gstatus.TIME_LIMIT]:
             opt = nan
+        elif status == gstatus.NUMERIC:
+            # Numerical trouble: return best incumbent value if available, else nan
+            opt = self.ObjVal if self.SolCount > 0 else nan
         else:
             raise Exception('Status code ' + str(status) + " not yet handeld.")
         return opt

--- a/tests/test_10_gene_design_validity.py
+++ b/tests/test_10_gene_design_validity.py
@@ -1,0 +1,113 @@
+"""Regression tests for gene-level strain design validity (issues #43, #44).
+
+These guard the invariant that every returned gene-based strain design, when re-applied to the
+original model, actually satisfies the PROTECT modules and renders the SUPPRESS modules infeasible —
+the class of check that was missing when #44 (PROTECT violated by gene_kos) slipped through. Also
+guards #43 (neutral gene KOs / gene-name vs gene-id handling).
+"""
+import pytest
+from math import inf
+from cobra.io import read_sbml_model
+import straindesign as sd
+from straindesign.names import (MODULES, MAX_COST, MAX_SOLUTIONS, SOLUTION_APPROACH,
+                                KOCOST, GKOCOST, SOLVER)
+from straindesign import SUPPRESS, PROTECT
+
+TOL = 1e-6
+
+
+def _max_flux(model, rid):
+    with model:
+        model.objective = rid
+        model.objective_direction = "maximize"
+        s = model.optimize()
+        return s.objective_value if s.status == "optimal" else None
+
+
+def _apply_gene_design(model, design):
+    """Apply a (stripped) gene/reaction design to `model` in-place via cobra GPR knockout."""
+    for k, v in design.items():
+        if any(op in str(k) for op in ["<=", ">=", "<", ">", "="]):
+            continue  # regulatory intervention: not exercised in these pure-KO tests
+        if v in (-1, False):
+            if k in model.genes:
+                model.genes.get_by_id(k).knock_out()
+            elif model.reactions.has_id(k):
+                model.reactions.get_by_id(k).bounds = (0.0, 0.0)
+
+
+def _gpr_mcs_setup(model, gko_cost, solver, approach):
+    modules = [sd.SDModule(model, SUPPRESS, constraints=["1.0 rd_ex >= 1.0 "]),
+               sd.SDModule(model, PROTECT, constraints=[[{'r_bm': 1.0}, '>=', 1.0]])]
+    return {MODULES: modules, MAX_COST: 3, MAX_SOLUTIONS: inf, SOLUTION_APPROACH: approach,
+            KOCOST: {'rs_up': 1.0, 'rd_ex': 1.0, 'rp_ex': 1.1},
+            GKOCOST: gko_cost, SOLVER: solver}
+
+
+@pytest.fixture
+def gpr_path():
+    import os
+    return os.path.join(os.path.dirname(__file__), "model_gpr.xml")
+
+
+def test_gene_kos_designs_satisfy_protect_and_suppress(gpr_path, curr_solver, comp_approach):
+    """#44 regression: every returned gene design must satisfy PROTECT (r_bm>=1) and enforce
+    SUPPRESS (max rd_ex < 1) when re-evaluated on a fresh model."""
+    if curr_solver == "glpk" and comp_approach == "populate":
+        pytest.skip("GLPK cannot reliably populate")
+    model = read_sbml_model(gpr_path)
+    gko = {g.id: 1.0 for g in model.genes}
+    sol = sd.compute_strain_designs(model, sd_setup=_gpr_mcs_setup(model, gko, curr_solver, comp_approach))
+    designs = sol.get_gene_sd()
+    assert designs, "expected at least one strain design"
+    for i, d in enumerate(designs):
+        m = read_sbml_model(gpr_path)
+        _apply_gene_design(m, d)
+        max_bm = _max_flux(m, "r_bm")
+        assert max_bm is not None and max_bm >= 1.0 - TOL, \
+            f"design {i} VIOLATES PROTECT (max r_bm={max_bm}): {d}"
+        max_rd = _max_flux(m, "rd_ex")
+        assert max_rd is None or max_rd < 1.0 + TOL, \
+            f"design {i} fails to SUPPRESS rd_ex (max rd_ex={max_rd}): {d}"
+
+
+def test_gene_names_equivalent_to_ids_no_neutral_kos(gpr_path):
+    """#43 regression: gko_cost keyed by gene NAMES must give the same valid designs as by gene IDs,
+    and must not contain neutral gene KOs (a gene KO whose associated reactions are not knocked)."""
+    preferred = [s for s in ["cplex", "scip", "gurobi"] if s in sd.avail_solvers]
+    if not preferred:
+        pytest.skip("requires cplex/scip/gurobi")
+    solver = preferred[0]
+    model = read_sbml_model(gpr_path)
+    if not all(g.name for g in model.genes):
+        pytest.skip("model has no gene names")
+
+    def run(by_names):
+        m = read_sbml_model(gpr_path)
+        gko = {(g.name if by_names else g.id): 1.0 for g in m.genes}
+        sol = sd.compute_strain_designs(m, sd_setup=_gpr_mcs_setup(m, gko, solver, "any"))
+        return sol
+
+    def neutral_count(sol, m):
+        n = 0
+        for gdes, rdes in zip(sol.gene_sd, sol.reaction_sd):  # unstripped attrs
+            ko_reacs = {k for k, v in rdes.items() if v in (-1, 0.0, False) and m.reactions.has_id(k)}
+            for k, v in gdes.items():
+                if v != -1:
+                    continue
+                g = m.genes.get_by_id(k) if m.genes.has_id(k) else \
+                    next((gg for gg in m.genes if gg.name == k), None)
+                if g is None:
+                    continue  # reaction-level KO, not a gene
+                assoc = {r.id for r in g.reactions}
+                if assoc and not (assoc & ko_reacs):
+                    n += 1
+        return n
+
+    m = read_sbml_model(gpr_path)
+    sol_ids = run(False)
+    sol_names = run(True)
+    assert neutral_count(sol_ids, m) == 0, "neutral gene KOs found with gene IDs"
+    assert neutral_count(sol_names, m) == 0, "neutral gene KOs found with gene NAMES (#43)"
+    # same number of (valid) gene designs regardless of id/name keying
+    assert len(sol_ids.get_gene_sd()) == len(sol_names.get_gene_sd())

--- a/tests/test_11_gene_regulatory_compression.py
+++ b/tests/test_11_gene_regulatory_compression.py
@@ -1,0 +1,95 @@
+"""Regression tests for gene-regulatory correctness under compression.
+
+A gene controlling several reactions that get merged BEFORE GPR integration would otherwise be
+hooked to the merged reaction with the wrong (collapsed) stoichiometry, so a gene-regulatory bound
+(g <= X / g >= X) is mis-scaled vs the uncompressed model. The fix exempts gene-controlled reactions
+from coupled merging in COMPRESS#1 (`no_coupled_compress_reacs`). These tests pin both the exemption
+mechanism and the corrected gene-regulatory multiplicity.
+"""
+import pytest
+from cobra import Model, Reaction, Metabolite
+import straindesign as sd
+from straindesign.networktools import extend_model_gpr
+from straindesign.compression import compress_model
+from straindesign.names import MAXIMIZE
+
+TOL = 1e-6
+
+
+def _fba(model, obj):
+    return sd.fba(model, obj=obj, obj_sense=MAXIMIZE).objective_value
+
+
+def _remap_obj(obj, cmap):
+    obj = dict(obj)
+    for step in cmap:
+        for new_r, old in step["reac_map_exp"].items():
+            for o in list(obj.keys()):
+                if o in old:
+                    obj[new_r] = obj.pop(o) * float(old[o])
+    return obj
+
+
+def _coupled_chain():
+    m = Model("chain")
+    mets = {x: Metabolite(x) for x in "ABCD"}
+    m.add_metabolites(list(mets.values()))
+    vin = Reaction("vin"); vin.add_metabolites({mets["A"]: 1}); vin.bounds = (0, 10)
+    r1 = Reaction("r1"); r1.add_metabolites({mets["A"]: -1, mets["B"]: 1}); r1.bounds = (0, 1000)
+    r2 = Reaction("r2"); r2.add_metabolites({mets["B"]: -1, mets["C"]: 1}); r2.bounds = (0, 1000)
+    r3 = Reaction("r3"); r3.add_metabolites({mets["C"]: -1, mets["D"]: 1}); r3.bounds = (0, 1000)
+    vout = Reaction("vout"); vout.add_metabolites({mets["D"]: -1}); vout.bounds = (0, 1000)
+    m.add_reactions([vin, r1, r2, r3, vout]); m.objective = "vout"
+    return m
+
+
+def test_coupled_exemption_keeps_reaction_and_merges_rest():
+    """Protecting one reaction in a coupled group keeps it intact while the rest still merge,
+    and flux space is preserved."""
+    base = _fba(_coupled_chain(), {"vout": 1})
+
+    m_full = _coupled_chain(); compress_model(m_full)
+    assert len(m_full.reactions) == 1, "unprotected coupled chain should fully collapse"
+
+    m_prot = _coupled_chain()
+    cmap = compress_model(m_prot, no_coupled_compress_reacs={"r2"})
+    ids = [r.id for r in m_prot.reactions]
+    assert any(r.id == "r2" for r in m_prot.reactions), "protected reaction r2 must be kept intact"
+    assert any(("r1" in i and "r3" in i) for i in ids), "r1 and r3 should still merge together"
+    obj = _remap_obj({"vout": 1}, cmap)
+    assert abs(base - _fba(m_prot, obj)) < TOL, "compression must preserve flux space"
+
+
+def _gene_model():
+    """g1 controls r1 (A->2B) and r2 (B->C), which are coupled 1:2."""
+    m = Model("g"); A, B, C = Metabolite("A"), Metabolite("B"), Metabolite("C")
+    m.add_metabolites([A, B, C])
+    vS = Reaction("vS"); vS.add_metabolites({A: 1}); vS.bounds = (0, 10)
+    r1 = Reaction("r1"); r1.add_metabolites({A: -1, B: 2}); r1.bounds = (0, 1000); r1.gene_reaction_rule = "g1"
+    r2 = Reaction("r2"); r2.add_metabolites({B: -1, C: 1}); r2.bounds = (0, 1000); r2.gene_reaction_rule = "g1"
+    vC = Reaction("vC"); vC.add_metabolites({C: -1}); vC.bounds = (0, 1000)
+    m.add_reactions([vS, r1, r2, vC]); m.objective = "vC"
+    return m
+
+
+def _max_C_under_g1_le_1(protect):
+    m = _gene_model()
+    cmap = compress_model(m, no_coupled_compress_reacs=({"r1", "r2"} if protect else set()),
+                          propagate_gpr=True)
+    extend_model_gpr(m, use_names=False)
+    m.reactions.g1.upper_bound = 1.0
+    return _fba(m, _remap_obj({"vC": 1}, cmap))
+
+
+def test_gene_regulatory_multiplicity_preserved_under_compression():
+    """With g1 controlling coupled r1,r2, the regulatory bound g1<=1 must give the same max product
+    compressed (with protection) as uncompressed; without protection it is wrong (3x)."""
+    mu = _gene_model(); extend_model_gpr(mu, use_names=False); mu.reactions.g1.upper_bound = 1.0
+    ref = _fba(mu, {"vC": 1})
+    assert abs(ref - 2.0 / 3.0) < 1e-4, "reference should be 2/3"
+
+    assert abs(_max_C_under_g1_le_1(protect=True) - ref) < 1e-4, \
+        "protected compression must match the uncompressed gene-regulatory result"
+    # sanity: the bug (no protection) would give 2.0, i.e. 3x off
+    assert abs(_max_C_under_g1_le_1(protect=False) - 2.0) < 1e-4, \
+        "unprotected compression collapses the gene multiplicity (documents the bug)"


### PR DESCRIPTION
## Two fixes: compression/gene-regulatory interventions and solver robustness

Two independent fixes found while reviewing gene-level strain design under network compression.

### 1. Gene-regulatory interventions are now correct under compression

**Problem.** When a gene controls several reactions that get flux-coupled and merged in the **first** compression pass (before GPR integration), `extend_model_gpr` later hooks the merged reaction to the gene with a single `g_<gene>` stoichiometry (coefficient 1), losing the fractionality that can arise from the compression and reaction merging. A gene-regulatory bound (`g <= X` / `g >= X`) is then **mis-scaled** vs the uncompressed model.

**Minimal repro** — `g1` controls coupled `r1: A→2B` and `r2: B→C` (so `v_r2 = 2·v_r1`), with `g1 <= 1`:

| | max product |
|---|---|
| uncompressed | **0.667** |
| compressed (before fix) | **2.0** (3× off) |

**Root cause.** The loss happens specifically in COMPRESS#1, where no `g_gene` metabolite exists yet. If the reactions are merged in COMPRESS#2 — after GPR integration, when `g_gene` is a real metabolite — compression is exact.

**Fix.** Added a keep-but-don't-merge exemption to the Python coupled compressor (`no_coupled_compress_reacs` / `protected`): `_find_coupled_groups` skips protected reaction indices (those that involve genes that are part of regulatory interventions), so the rest of a coupled group still merges. `compute_strain_designs` now exempts reactions controlled by **regulatory** genes from COMPRESS#1; they merge correctly in COMPRESS#2. Mirrors the existing Java `suppressed_reactions` concept, but *keeps* the reactions instead of removing them.

**Scope.** Only gene-**regulatory** interventions are affected/protected. Gene knockouts (`=0`) and knock-ins (unbounded when added) are unaffected, so the common path is untouched. Cost is negligible — only the few regulatory-gene reactions stay un-merged in COMPRESS#1 (verified: protecting one reaction in a coupled chain still merges the rest, FBA preserved).

Relates to #28.

### 2. Solver robustness on numerically hard MILPs

Large MCS/Farkas MILPs can return a numerical-trouble status that the interfaces didn't handle, crashing the whole computation:
- Gurobi status `12` (`NUMERIC`) → `Exception('Status code 12 not yet handeld')`
- CPLEX status `5`/`6` (optimal with unscaled infeasibilities) → `Exception('Case not yet handeld')`

Now handled gracefully: Gurobi retries once with `NumericFocus=3`, then falls back to the best incumbent (warned) or reports no solution; CPLEX accepts the solution with a warning. Normal solves are unchanged (additive `elif` branches).

### Tests
- `tests/test_11_gene_regulatory_compression.py` — the 3× case now matches uncompressed; coupled-exemption keeps one reaction while merging the rest of its group (FBA preserved).
- `tests/test_10_gene_design_validity.py` — guards that returned gene designs satisfy their PROTECT/SUPPRESS modules and that gene-name vs gene-id keying is consistent.
- No regression in the existing compression / strain-design / gene-KO suites.

### Notes
- `suppressed_reactions`/protection-set arguments standardized to `set()` defaults (read-only; behaves identically to the previous `None`).
- No performance impact on the common (gene-KO / no-regulatory) path.

Co-authored by Claude Code.
