### PR TITLE
Gurobi env and interrupt

### DIFF
--- a/straindesign/cplex_interface.py
+++ b/straindesign/cplex_interface.py
@@ -187,7 +187,7 @@ class Cplex_MILP_LP(Cplex):
             if status in [1, 101, 102, 115, 128, 129, 130]:  # solution integer optimal
                 min_cx = self.solution.get_objective_value()
                 status = OPTIMAL
-            elif status == 108:  # timeout without solution
+            elif status in [108, 114]:  # timeout/abort without solution
                 x = [nan] * self.variables.get_num()
                 min_cx = nan
                 status = TIME_LIMIT
@@ -197,7 +197,7 @@ class Cplex_MILP_LP(Cplex):
                 min_cx = nan
                 status = INFEASIBLE
                 return x, min_cx, status
-            elif status in [11, 107]:  # timeout with solution
+            elif status in [11, 13, 107, 113]:  # timeout/abort with solution
                 min_cx = self.solution.get_objective_value()
                 status = TIME_LIMIT_W_SOL
             elif status in [2, 4, 118, 119]:  # solution unbounded
@@ -240,11 +240,11 @@ class Cplex_MILP_LP(Cplex):
         try:
             super().solve()  # call parent solve function (that was overwritten in this class)
             status = self.solution.get_status()
-            if status in [1, 101, 102, 107, 115, 128, 129, 130]:  # optimal (LP: 1, MIP: 101/102/107/115/128-130)
+            if status in [1, 101, 102, 107, 113, 115, 128, 129, 130]:  # optimal or abort with solution
                 opt = self.solution.get_objective_value()
             elif status in [2, 4, 118, 119]:  # unbounded (LP: 2/4, MIP: 118/119)
                 opt = -inf
-            elif status in [3, 103, 108]:  # infeasible (LP: 3, MIP: 103/108)
+            elif status in [3, 13, 103, 108, 114]:  # infeasible or abort without solution
                 opt = nan
             elif status in [5, 6]:  # optimal/best with unscaled infeasibilities (numerical)
                 opt = self.solution.get_objective_value()
@@ -277,7 +277,7 @@ class Cplex_MILP_LP(Cplex):
             if status in [101, 102, 115, 128, 129, 130]:  # solution integer optimal
                 min_cx = self.solution.get_objective_value()
                 status = OPTIMAL
-            elif status == 108:  # timeout without solution
+            elif status in [108, 114]:  # timeout/abort without solution
                 x = []
                 min_cx = nan
                 status = TIME_LIMIT
@@ -287,7 +287,7 @@ class Cplex_MILP_LP(Cplex):
                 min_cx = nan
                 status = INFEASIBLE
                 return x, min_cx, status
-            elif status == 107:  # timeout with solution
+            elif status in [13, 107, 113]:  # timeout/abort with solution
                 min_cx = self.solution.get_objective_value()
                 status = TIME_LIMIT_W_SOL
             elif status in [118, 119]:  # solution unbounded

--- a/straindesign/gurobi_interface.py
+++ b/straindesign/gurobi_interface.py
@@ -96,7 +96,11 @@ class Gurobi_MILP_LP(gp.Model):
     """
 
     def __init__(self, c=None, A_ineq=None, b_ineq=None, A_eq=None, b_eq=None, lb=None, ub=None, vtype=None, indic_constr=None, seed=None, milp_threads=None):
-        super().__init__()
+        # Create a quiet environment to suppress license messages on model creation
+        env = gp.Env(empty=True)
+        env.setParam('OutputFlag', 0)
+        env.start()
+        super().__init__(env=env)
         try:
             numvars = A_ineq.shape[1]
         except:

--- a/straindesign/gurobi_interface.py
+++ b/straindesign/gurobi_interface.py
@@ -28,6 +28,18 @@ import logging
 
 gstatus = grb.Status
 
+# Shared quiet environment — avoids creating a new license session per model
+_quiet_env = None
+
+def _get_quiet_env():
+    """Return a shared Gurobi environment with OutputFlag=0."""
+    global _quiet_env
+    if _quiet_env is None:
+        _quiet_env = gp.Env(empty=True)
+        _quiet_env.setParam('OutputFlag', 0)
+        _quiet_env.start()
+    return _quiet_env
+
 
 class Gurobi_MILP_LP(gp.Model):
     """Gurobi interface for MILP and LP
@@ -96,11 +108,7 @@ class Gurobi_MILP_LP(gp.Model):
     """
 
     def __init__(self, c=None, A_ineq=None, b_ineq=None, A_eq=None, b_eq=None, lb=None, ub=None, vtype=None, indic_constr=None, seed=None, milp_threads=None):
-        # Create a quiet environment to suppress license messages on model creation
-        env = gp.Env(empty=True)
-        env.setParam('OutputFlag', 0)
-        env.start()
-        super().__init__(env=env)
+        super().__init__(env=_get_quiet_env())
         try:
             numvars = A_ineq.shape[1]
         except:

--- a/straindesign/gurobi_interface.py
+++ b/straindesign/gurobi_interface.py
@@ -193,12 +193,14 @@ class Gurobi_MILP_LP(gp.Model):
         if status in [gstatus.OPTIMAL, gstatus.SOLUTION_LIMIT, gstatus.SUBOPTIMAL, gstatus.USER_OBJ_LIMIT]:  # solution
             min_cx = self.ObjVal
             status = OPTIMAL
-        elif status == gstatus.TIME_LIMIT and not hasattr(self.getVars()[0], 'X'):  # timeout without solution
+        elif status in [gstatus.TIME_LIMIT, gstatus.INTERRUPTED] and not hasattr(self.getVars()[0], 'X'):
+            # timeout or Ctrl+C without solution
             x = [nan] * self.NumVars
             min_cx = nan
             status = TIME_LIMIT
             return x, min_cx, status
-        elif status == gstatus.TIME_LIMIT and hasattr(self.getVars()[0], 'X'):
+        elif status in [gstatus.TIME_LIMIT, gstatus.INTERRUPTED] and hasattr(self.getVars()[0], 'X'):
+            # timeout or Ctrl+C with solutions found — return them
             min_cx = self.ObjVal
             status = TIME_LIMIT_W_SOL
         elif status in [gstatus.INF_OR_UNBD, gstatus.UNBOUNDED, gstatus.INFEASIBLE]:
@@ -263,7 +265,7 @@ class Gurobi_MILP_LP(gp.Model):
             opt = self.ObjVal
         elif status in [gstatus.INF_OR_UNBD, gstatus.UNBOUNDED]:
             opt = -inf
-        elif status in [gstatus.INFEASIBLE, gstatus.TIME_LIMIT]:
+        elif status in [gstatus.INFEASIBLE, gstatus.TIME_LIMIT, gstatus.INTERRUPTED]:
             opt = nan
         elif status == gstatus.NUMERIC:
             # Numerical trouble: return best incumbent value if available, else nan
@@ -297,7 +299,7 @@ class Gurobi_MILP_LP(gp.Model):
             if status in [2, 10, 13, 15]:  # solution integer optimal
                 min_cx = self.ObjVal
                 status = OPTIMAL
-            elif status == 9 and not hasattr(self.getVars()[0], 'X'):  # timeout without solution
+            elif status in [9, 11] and not hasattr(self.getVars()[0], 'X'):  # timeout/interrupt without solution
                 x = [nan] * len(self.getVars())
                 min_cx = nan
                 status = TIME_LIMIT
@@ -307,7 +309,7 @@ class Gurobi_MILP_LP(gp.Model):
                 min_cx = nan
                 status = INFEASIBLE
                 return x, min_cx, status
-            elif status == 9 and hasattr(self.getVars()[0], 'X'):  # timeout with solution
+            elif status in [9, 11] and hasattr(self.getVars()[0], 'X'):  # timeout/interrupt with solution
                 min_cx = self.ObjVal
                 status = TIME_LIMIT_W_SOL
             elif status in [4, 5]:  # solution unbounded

--- a/straindesign/scip_interface.py
+++ b/straindesign/scip_interface.py
@@ -211,7 +211,7 @@ class SCIP_MILP(pso.Model):
             if status in ['optimal']:  # solution
                 min_cx = self.getObjVal()
                 status = OPTIMAL
-            elif status == 'timelimit' and self.getSols() == []:  # timeout without solution
+            elif status in ['timelimit', 'userinterrupt'] and self.getSols() == []:  # timeout/interrupt without solution
                 x = [nan] * len(self.vars)
                 min_cx = nan
                 status = TIME_LIMIT
@@ -221,7 +221,7 @@ class SCIP_MILP(pso.Model):
                 min_cx = nan
                 status = INFEASIBLE
                 return x, min_cx, status
-            elif status == 'timelimit' and not self.getSols() == []:  # timeout with solution
+            elif status in ['timelimit', 'userinterrupt'] and not self.getSols() == []:  # timeout/interrupt with solution
                 min_cx = self.getObjVal()
                 status = TIME_LIMIT_W_SOL
             elif status in ['inforunbd', 'unbounded']:  # solution unbounded
@@ -267,7 +267,7 @@ class SCIP_MILP(pso.Model):
                 opt = self.getObjVal()
             elif status == 'infeasible':
                 opt = nan
-            elif status in ['timelimit', 'unknown']:  # salvage incumbent objective if one exists
+            elif status in ['timelimit', 'unknown', 'userinterrupt']:  # salvage incumbent objective if one exists
                 opt = self.getObjVal() if self.getSols() else nan
             elif status in ['inforunbd', 'unbounded']:
                 opt = -inf


### PR DESCRIPTION
- Catch Ctrl+C interruption for Gurobi and return solution if there is one
- Use shared quiet Gurobi environment to create a new license session per model (improvement for Gurobi WSL license users)