### PR TITLE
resolve gene/reaction constraints against the uncompressed model

### DIFF
--- a/straindesign/speedy_fva.py
+++ b/straindesign/speedy_fva.py
@@ -319,6 +319,7 @@ def speedy_fva(model, **kwargs):
     t_phase = {}
     _tp0 = _time.perf_counter()
 
+    orig_model = model  # uncompressed model: carries the user-facing reaction and gene IDs
     if compress:
         model, cmp_maps = _compress_for_fva(model)
     t_phase['compress'] = _time.perf_counter() - _tp0
@@ -329,7 +330,8 @@ def speedy_fva(model, **kwargs):
     has_constraints = CONSTRAINTS in kwargs and kwargs[CONSTRAINTS]
     if has_constraints:
         from straindesign.networktools import resolve_gene_constraints
-        kwargs[CONSTRAINTS] = resolve_gene_constraints(model, kwargs[CONSTRAINTS])
+        # Resolve gene/reaction constraints in the original ID space, then map onto the compressed model
+        kwargs[CONSTRAINTS] = resolve_gene_constraints(orig_model, kwargs[CONSTRAINTS])
         kwargs[CONSTRAINTS] = parse_constraints(kwargs[CONSTRAINTS], orig_reaction_ids)
         if cmp_maps:
             kwargs[CONSTRAINTS] = _map_constraints(


### PR DESCRIPTION
speedy_fva auto-compresses the model (coupled reaction lumping) when it has
>= 200 reactions, then called resolve_gene_constraints() on the *compressed*
model. Any user constraint referencing a reaction that had been lumped away (e.g. an exchange like EX_o2_e coupled with its transporter) then raised "Expression invalid. Unknown identifier ..." even though the reaction exists in the model the caller passed in.

The surrounding pipeline already parses constraints in the original ID space (parse_constraints uses orig_reaction_ids) and maps them onto the compressed model afterwards (_map_constraints), so constraint resolution must also run in the original ID space. Keep a handle to the uncompressed model and resolve gene/reaction constraints against it.

Verified on iML1515 (2712 rxns): fva(cmp, constraints=['EX_o2_e = 0', 'BIOMASS_... = <opt>']) with auto-compression enabled now returns the same ranges as the compress=False path (previously it raised). test_02 + test_08 (79 tests) pass.