### PR TITLE
fix(release): repair the publish workflow after the setup.py removal

### DIFF
--- a/.github/update_version.py
+++ b/.github/update_version.py
@@ -1,13 +1,47 @@
+"""Set the version number in one of the files that declare it.
+
+Usage: python update_version.py <file> <version>
+
+Each pattern below targets exactly one declaration style. A file that matches
+none of them is treated as an error rather than rewritten unchanged, so a
+renamed key or a reformatted file fails the release run instead of shipping a
+stale version number.
+"""
 import re
 import sys
 
-file_i = sys.argv[1]
-version = sys.argv[2]
+# (pattern, flags) -- group 1 is the prefix up to the opening quote, group 2 the
+# closing quote, so the version itself is whatever sits between them.
+PATTERNS = (
+    # pyproject.toml       version = "1.19"
+    (r'^(version\s*=\s*")[^"]*(")', re.M),
+    # docs/source/conf.py  release = "1.19"
+    (r'^(release\s*=\s*")[^"]*(")', re.M),
+    # conda-recipe/meta.yaml  {% set version = '1.19' %}
+    (r"(\{%\s*set\s+version\s*=\s*')[^']*(')", 0),
+)
 
-with open(file_i, 'r') as f:
-    content = f.read()
-    content_new = re.sub(r"(?<=version\=\").*?(?=\")", str(version), content, flags=re.M)
-    content_new = re.sub(r"(?<=version \= ').*?(?=')", str(version), content_new, flags=re.M)
-    content_new = re.sub(r"(?<=release \= \").*?(?=\")", str(version), content_new, flags=re.M)
-with open(file_i, 'w') as f:
-    f.write(content_new)
+
+def main():
+    if len(sys.argv) != 3:
+        sys.exit(__doc__)
+    path, version = sys.argv[1], sys.argv[2]
+
+    with open(path, 'r') as f:
+        content = f.read()
+
+    total = 0
+    for pattern, flags in PATTERNS:
+        content, count = re.subn(pattern, r'\g<1>' + version + r'\g<2>', content, flags=flags)
+        total += count
+
+    if not total:
+        sys.exit(f'{path}: no version declaration matched, version NOT updated')
+
+    with open(path, 'w') as f:
+        f.write(content)
+    print(f'{path}: set version to {version} ({total} occurrence(s))')
+
+
+if __name__ == '__main__':
+    main()

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -29,7 +29,7 @@ jobs:
         python-version: '3.x'
     - name: update version number
       run: |
-        python ./.github/update_version.py setup.py ${{ github.event.inputs.version }}
+        python ./.github/update_version.py pyproject.toml ${{ github.event.inputs.version }}
         python ./.github/update_version.py conda-recipe/meta.yaml ${{ github.event.inputs.version }}
         python ./.github/update_version.py docs/source/conf.py ${{ github.event.inputs.version }}
     - name: install yapf
@@ -59,14 +59,17 @@ jobs:
         gh release create "v${{ github.event.inputs.version }}" \
           --title "v${{ github.event.inputs.version }}" \
           --notes "${{ github.event.inputs.description }}"
-    - name: Install setuptools, wheel and twine
+    - name: Install build and twine
       run: |
-        pip install build setuptools wheel twine
+        pip install --upgrade build twine
     - name: Clean PyPi build directories
       run: rm -rf dist
     - name: Build for PyPi
       run: |
-        python setup.py sdist bdist_wheel
+        python -m build
+    - name: Check the built distributions
+      run: |
+        twine check dist/*
     - name: Publish to PyPI
       uses: pypa/gh-action-pypi-publish@release/v1
       with:

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 [![Documentation Status](https://readthedocs.org/projects/straindesign/badge/?version=latest)](https://readthedocs.org/projects/straindesign/builds/)
 [![Supported Python Versions](https://img.shields.io/pypi/pyversions/straindesign.svg)](https://pypi.org/project/straindesign/)
 [![CI-test Status](https://github.com/klamt-lab/straindesign/workflows/CI-test/badge.svg)](https://github.com/klamt-lab/straindesign/actions/workflows/CI-test.yml)
-[![License](https://img.shields.io/pypi/l/straindesign.svg)](https://www.gnu.org/licenses/old-licenses/lgpl-2.0.html)
+[![License](https://img.shields.io/pypi/l/straindesign.svg)](https://github.com/klamt-lab/straindesign/blob/main/LICENSE)
 [![Code style: YAPF](https://img.shields.io/badge/code%20style-yapf-blue)](https://github.com/google/yapf)
 
 ## A COBRApy<a href="#ref1"><sup>[1]</sup></a>-based package for computational design of metabolic networks

--- a/Update_version.md
+++ b/Update_version.md
@@ -1,33 +1,42 @@
-This is only needed for manual version upgrading. A versioning script is availabe in GitHub actions.
+Releases are normally cut by the `Build and Upload Python Package` GitHub action,
+which is triggered manually and takes the new version number as its input. It
+bumps the version, formats the repository, creates the tag and release, and
+uploads to PyPI and the `cnapy` Anaconda channel. The steps below are the manual
+equivalent, for the case where the action cannot be used.
 
 ## In any case:
-1. Update version number in `conda-recipe/meta.yaml`. Update dependencies/versions and description if necessary
-2. Update version number in `setup.py`. Update dependencies/versions and description and `requirements.txt` if necessary.
-3. Create a new tag/release on GitHub with matching version number (e.g. `v0.1`)
+1. Update the version number in `pyproject.toml`, `conda-recipe/meta.yaml` and
+   `docs/source/conf.py`. `python .github/update_version.py <file> <version>`
+   does this per file and fails if the file declares no version, so a silent
+   miss is not possible. Update dependencies/versions and the description in
+   `pyproject.toml` and `requirements.txt` if necessary.
+2. Create a new tag/release on GitHub with a matching version number (e.g. `v0.1`)
 
-## Building PyPi package
+## Building the PyPI package
 
 ### Prerequisites
-1. Install newest version of pip (`python -m pip install --upgrade pip` or `conda update pip`)
-2. Install twain (`pip install twain` or `conda install twain`)
+1. Install the newest version of pip (`python -m pip install --upgrade pip` or `conda update pip`)
+2. Install the build frontend and twine (`pip install --upgrade build twine`)
 
 ### Build and upload package
 
-1. Navigate to package folder and build package with `python setup.py sdist bdist_wheel`
-2. Clean up dist folder (remove old version builds)
-3. Upload package source and wheel to PyPi via `twine upload dist/*` (Use PyPi credencials)
+1. Clean the dist folder (remove old version builds)
+2. Navigate to the package folder and build with `python -m build`, which produces
+   both the source distribution and the wheel
+3. Verify the metadata renders on PyPI with `twine check dist/*`
+4. Upload the source distribution and wheel via `twine upload dist/*` (use PyPI credentials)
 
-## Building Conda package
+## Building the Conda package
 
 ### Prerequisites
 1. Create a conda environment to build the package (e.g. `conda create -n straindesign-build`)
-2. Activate environment (`conda activate straindesign-build`)
-3. Install requirements (`conda install anaconda-client conda-build`)
+2. Activate the environment (`conda activate straindesign-build`)
+3. Install the requirements (`conda install anaconda-client conda-build`)
 
 ### Build and upload package
 
-1. Navigate to package folder and build package with `conda-build conda-recipe/. -c conda-forge --croot conda-bld`
-2. Clean up conda-bld folder (remove old version builds)
+1. Navigate to the package folder and build with `conda-build conda-recipe/. -c conda-forge --croot conda-bld`
+2. Clean up the conda-bld folder (remove old version builds)
 3. `anaconda login`
 4. `anaconda upload -u cnapy conda-bld/noarch/straindesign*`
 5. Clean up with conda

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -13,13 +13,18 @@ requirements:
   build:
     - python
     - pip
-    - setuptools >=64
+    - setuptools >=77
     - wheel
   run:
     - python
     - scipy
-    - matplotlib
+    - matplotlib-base
     - psutil
+    - numpy
+    - pandas
+    - optlang
+    - swiglpk
+    - pyscipopt
     - conda-forge:cobra
 
 build:

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -33,8 +33,8 @@ test:
 
 about:
   home:  https://github.com/klamt-lab/straindesign
-  license: Apache 2
-  license_family: MIT
+  license: Apache-2.0
+  license_family: Apache
   license_file: LICENSE
   summary: Computational strain design package for the COBRApy framework.
   doc_url: https://github.com/klamt-lab/straindesign

--- a/environment.yml
+++ b/environment.yml
@@ -5,6 +5,11 @@ channels:
 dependencies:
   - python
   - scipy
-  - matplotlib
+  - matplotlib-base
   - psutil
+  - numpy
+  - pandas
+  - optlang
+  - swiglpk
+  - pyscipopt
   - conda-forge::cobra

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,12 +1,12 @@
 [build-system]
-requires = ["setuptools>=64", "wheel"]
+requires = ["setuptools>=77", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [project]
 name = "straindesign"
 version = "1.18"
 description = "Computational strain design package for the COBRApy framework"
-readme = {text = "Computational strain design package for the COBRApy framework, offering standard and advanced tools for the analysis and redesign of biological networks", content-type = "text/plain"}
+readme = "README.md"
 license = "Apache-2.0"
 requires-python = ">=3.10"
 authors = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,20 @@ dependencies = [
     "scipy",
     "matplotlib",
     "psutil",
+    # Imported directly by this package, but every one of them is already a hard
+    # requirement of cobra. They are listed so the imports are declared, and left
+    # deliberately unpinned: contributing no version constraint leaves cobra the
+    # sole authority on which versions get resolved. Do not add bounds here --
+    # that would start a fight with cobra over versions we have no opinion on.
+    "numpy",
+    "pandas",
+    "optlang",
+    "swiglpk",
+    # The only free solver that handles indicator constraints natively. GLPK has
+    # to translate them into big-M, which is documented to give incorrect results
+    # (see glpk_interface.py and test_07_compression.py), so without this a
+    # default install would have no solver able to express the formulation.
+    "pyscipopt",
 ]
 
 [project.urls]

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,8 @@ cobra
 scipy
 matplotlib
 psutil
+numpy
+pandas
+optlang
+swiglpk
+pyscipopt

--- a/straindesign/__init__.py
+++ b/straindesign/__init__.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 #
-# Copyright 2022 Max Planck Insitute Magdeburg
+# Copyright 2022-2026 Max Planck Institute Magdeburg
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/straindesign/compression.py
+++ b/straindesign/compression.py
@@ -1,3 +1,19 @@
+#!/usr/bin/env python3
+#
+# Copyright 2025-2026 Max Planck Institute Magdeburg
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 """
 Metabolic network compression using nullspace-based coupling detection.
 

--- a/straindesign/compute_strain_designs.py
+++ b/straindesign/compute_strain_designs.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 #
-# Copyright 2022 Max Planck Insitute Magdeburg
+# Copyright 2022-2026 Max Planck Institute Magdeburg
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/straindesign/cplex_interface.py
+++ b/straindesign/cplex_interface.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 #
-# Copyright 2022 Max Planck Insitute Magdeburg
+# Copyright 2022-2026 Max Planck Institute Magdeburg
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/straindesign/glpk_interface.py
+++ b/straindesign/glpk_interface.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 #
-# Copyright 2022 Max Planck Insitute Magdeburg
+# Copyright 2022-2026 Max Planck Institute Magdeburg
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/straindesign/gurobi_interface.py
+++ b/straindesign/gurobi_interface.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 #
-# Copyright 2022 Max Planck Insitute Magdeburg
+# Copyright 2022-2026 Max Planck Institute Magdeburg
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/straindesign/indicatorConstraints.py
+++ b/straindesign/indicatorConstraints.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 #
-# Copyright 2022 Max Planck Insitute Magdeburg
+# Copyright 2022-2026 Max Planck Institute Magdeburg
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/straindesign/lptools.py
+++ b/straindesign/lptools.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 #
-# Copyright 2022 Max Planck Insitute Magdeburg
+# Copyright 2022-2026 Max Planck Institute Magdeburg
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/straindesign/names.py
+++ b/straindesign/names.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 #
-# Copyright 2022 Max Planck Insitute Magdeburg
+# Copyright 2022-2026 Max Planck Institute Magdeburg
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/straindesign/networktools.py
+++ b/straindesign/networktools.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 #
-# Copyright 2022 Max Planck Insitute Magdeburg
+# Copyright 2022-2026 Max Planck Institute Magdeburg
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/straindesign/parse_constr.py
+++ b/straindesign/parse_constr.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 #
-# Copyright 2022 Max Planck Insitute Magdeburg
+# Copyright 2022-2026 Max Planck Institute Magdeburg
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/straindesign/pool.py
+++ b/straindesign/pool.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 #
-# Copyright 2022 Max Planck Insitute Magdeburg
+# Copyright 2022-2026 Max Planck Institute Magdeburg
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/straindesign/scip_interface.py
+++ b/straindesign/scip_interface.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 #
-# Copyright 2022 Max Planck Insitute Magdeburg
+# Copyright 2022-2026 Max Planck Institute Magdeburg
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/straindesign/solver_interface.py
+++ b/straindesign/solver_interface.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 #
-# Copyright 2022 Max Planck Insitute Magdeburg
+# Copyright 2022-2026 Max Planck Institute Magdeburg
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/straindesign/speedy_fva.py
+++ b/straindesign/speedy_fva.py
@@ -1,3 +1,19 @@
+#!/usr/bin/env python3
+#
+# Copyright 2026 Max Planck Institute Magdeburg
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 """Accelerated FVA using scan LPs and bound scanning.
 
 Standard FVA solves 2*n independent LPs (max and min for each reaction).

--- a/straindesign/strainDesignMILP.py
+++ b/straindesign/strainDesignMILP.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 #
-# Copyright 2022 Max Planck Insitute Magdeburg
+# Copyright 2022-2026 Max Planck Institute Magdeburg
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/straindesign/strainDesignModule.py
+++ b/straindesign/strainDesignModule.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 #
-# Copyright 2022 Max Planck Insitute Magdeburg
+# Copyright 2022-2026 Max Planck Institute Magdeburg
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/straindesign/strainDesignProblem.py
+++ b/straindesign/strainDesignProblem.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 #
-# Copyright 2022 Max Planck Insitute Magdeburg
+# Copyright 2022-2026 Max Planck Institute Magdeburg
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/straindesign/strainDesignSolutions.py
+++ b/straindesign/strainDesignSolutions.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 #
-# Copyright 2022 Max Planck Insitute Magdeburg
+# Copyright 2022-2026 Max Planck Institute Magdeburg
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.


### PR DESCRIPTION
setup.py was deleted when the project moved to pyproject.toml, but the release workflow still referenced it in two places, so it could not have produced a release: the version-bump step would raise FileNotFoundError and the build step called `python setup.py sdist bdist_wheel`. The migration landed after v1.18, so the workflow has never run against a setup.py-less tree -- PyPI 1.18 still advertises `requires_python: >=3.7`, the value from the old setup.py.

Build with `python -m build` and bump the version in pyproject.toml instead.

update_version.py silently did nothing to pyproject.toml. Its patterns matched `version="x"` (setup.py) and `version = 'x'` (meta.yaml), but pyproject declares `version = "x"` -- spaces and double quotes -- so it rewrote the file unchanged and exited 0. A release would have been tagged and uploaded under the previous version number. It now matches all three declaration styles and exits non-zero when a file declares no version at all, so a future rename fails the run rather than shipping a stale number.

Also:

- `readme` was inline text, so the PyPI project page showed a single sentence instead of README.md. Point it at the file; its images and badges already use absolute URLs, so it renders off-GitHub. Verified README.md ships in the sdist, which is what a conda-forge recipe would build from.
- Require setuptools>=77. `license = "Apache-2.0"` as a bare string is PEP 639, which older setuptools rejects, and both the conda recipe and conda-forge build with --no-build-isolation against whatever setuptools the host provides.
- Add `twine check dist/*` before upload.
- The conda recipe declared `license_family: MIT` for an Apache-2.0 package, and the README's license badge linked to LGPL-2.0.
- Refresh Update_version.md, which documented the setup.py flow.

Verified end to end: sdist and wheel build without isolation, metadata carries Description-Content-Type text/markdown with the full README, and the package installs from the sdist and imports.