### PR TITLE
ci(release): push the version bump with a deploy key, and restrict who can release

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -20,7 +20,23 @@ jobs:
     runs-on: ubuntu-latest
     environment: build_and_publish
     steps:
+    # Anyone with write access can dispatch a workflow, and this one publishes
+    # irreversibly to PyPI. Fail loudly rather than skipping, so a dispatch that
+    # does nothing cannot be mistaken for a release that worked.
+    - name: Restrict releases to the maintainer
+      if: github.actor != 'VonAlphaBisZulu'
+      run: |
+        echo "::error::Releases may only be dispatched by VonAlphaBisZulu (dispatched by: ${{ github.actor }})"
+        exit 1
+    # Checked out over SSH with a write deploy key. The ruleset protecting main
+    # requires changes to arrive by pull request and lists DeployKey as a bypass
+    # actor, so the version-bump commit can only be pushed with this key. The key
+    # is an environment secret of build_and_publish, so no other workflow can
+    # read it -- unlike a bypass for github-actions[bot], which would apply to
+    # every workflow in the repository.
     - uses: actions/checkout@v4
+      with:
+        ssh-key: ${{ secrets.RELEASE_DEPLOY_KEY }}
     - name: Print version number
       run: echo ${{ github.event.inputs.version }}
     - name: set up Python


### PR DESCRIPTION
Fixes the failed 1.19 dispatch ([run 30177587416](https://github.com/klamt-lab/straindesign/actions/runs/30177587416)).

## What happened

`push code to main` was rejected with `GH013`: the ruleset **Main edits only by PR** requires changes to arrive via pull request, and the workflow pushes the version bump directly.

**Nothing was lost.** Because the release steps were reordered in #74, the failure landed before anything irreversible: PyPI never saw 1.19 (the version is still free) and no tag or release was created. Under the old ordering this would have left a `v1.19` tag advertising a version that does not exist on PyPI.

## The fix

The ruleset **already lists `DeployKey` as a bypass actor**, so it needs no change:

```
actor_type=DeployKey       mode=always
actor_type=RepositoryRole  mode=always   (admin)
```

Checking out over SSH with a write deploy key is therefore sufficient. `actions/checkout` supports this directly, so the existing `git push` step is unchanged.

### Why a deploy key rather than `github-actions[bot]`

Ruleset bypasses are per **actor**, not per workflow. Adding `github-actions[bot]` would let *every* workflow in the repo with `contents: write` push to main unreviewed. The deploy key's private half is an **environment secret of `build_and_publish`**, and only jobs declaring that environment can read it — so the bypass is confined to this one workflow.

| Approach | Scope of the exception |
|---|---|
| `github-actions[bot]` bypass | every workflow, indefinitely |
| **Deploy key in the environment** | **only jobs declaring `build_and_publish`** |

Honest caveat: this is a long-lived credential, and a write deploy key may push to any branch in this repo. What is scoped is *who can read it*, not what it can do.

## Restricting dispatch

Any collaborator with write access can start a `workflow_dispatch`, and this one publishes to PyPI where a version number cannot be reused once taken. The run now fails unless dispatched by `VonAlphaBisZulu`. It **fails rather than skips** — a dispatch that quietly does nothing looks too much like one that worked.

## Required before the next dispatch

1. A write deploy key registered on the repository.
2. Its private half stored as `RELEASE_DEPLOY_KEY` in the `build_and_publish` environment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)