### PR TITLE
ci(release): publish to PyPI with trusted publishing

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -14,6 +14,10 @@ on:
 
 permissions:
   contents: write
+  # Lets the runner mint the short-lived OIDC token that PyPI trusted publishing
+  # exchanges for an upload token. Without it the publish step has no credential
+  # at all, now that no API token is stored.
+  id-token: write
 
 jobs:
   deploy:
@@ -82,10 +86,10 @@ jobs:
       run: git fetch
     - name: push code to main
       run: git push
+    # No password: the action falls back to trusted publishing, authenticating as
+    # this workflow in this repository against the publisher configured on PyPI.
     - name: Publish to PyPI
       uses: pypa/gh-action-pypi-publish@release/v1
-      with:
-        password: ${{ secrets.PYPI_API_TOKEN }}
     # Tag and release only once PyPI has accepted the upload. A version cannot be
     # re-uploaded to PyPI even after deletion, so the release must not advertise a
     # version that never made it there.


### PR DESCRIPTION
## This would have broken the next release

The stored PyPI API token is now deleted, but the publish step still passed:

```yaml
with:
  password: ${{ secrets.PYPI_API_TOKEN }}
```

A **missing secret resolves to an empty string** rather than failing the expression. So the next release would have reached the upload with no credential — and no OIDC token either, because `permissions:` did not request `id-token: write`.

It would have failed **late**. With the steps reordered in #74, the version bump is pushed to main *before* the upload, so the result would be main carrying a version that never reached PyPI, with no tag or release for it.

## The fix

Request `id-token: write` and drop the `password` input. `pypa/gh-action-pypi-publish` then falls back to trusted publishing, exchanging a short-lived OIDC token for an upload token against the publisher configured on PyPI.

Nothing durable is stored, so there is no token left to expire, leak, or rotate — which is the point of having deleted it.

## Secret references after this change

| Reference | Where it lives |
|---|---|
| `RELEASE_DEPLOY_KEY` | `build_and_publish` env ✅ |
| `NAME_GITHUB`, `MAIL_GITHUB` | `build_and_publish` env ✅ |
| `ANACONDA_API_TOKEN` | `build_and_publish` env ✅ (renewed, expires 2030-01-10) |
| ~~`PYPI_API_TOKEN`~~ | no longer referenced |

Repo-level secrets are now empty; everything the workflow needs is environment-scoped, and the job declares that environment.

## Before the next release

The PyPI publisher must match exactly: owner `klamt-lab`, repository `straindesign`, workflow `python-publish.yml`, environment `build_and_publish`. If the environment field was left blank on PyPI it matches any environment, which also works — but a *different* value would not.

🤖 Generated with [Claude Code](https://claude.com/claude-code)