### PR TITLE
Fix knock-in pricing in the cost filter, and restore negative intervention costs

### DIFF
--- a/straindesign/networktools.py
+++ b/straindesign/networktools.py
@@ -1361,11 +1361,22 @@ def filter_sd_maxcost(sd, max_cost, kocost, kicost):
     # introduced KIs and KOs carry values of +1.0 and -1.0 respectively
     # non-made KIs are marked by 0.0 and non-made KOs don't appear.
     # We count costs of interventions made, which are marked by v != 0.
+    # A reaction may occur in both cost dicts (kocost defaults to all reactions).
+    # The value's sign says which kind of intervention was made, so it selects
+    # the cost dict, matching how SDProblem prices interventions.
+    def itv_cost(k, v):
+        if v == 0:
+            return 0
+        if v > 0:  # knock-in
+            return kicost[k] if k in kicost else kocost.get(k, 0)
+        return kocost[k] if k in kocost else kicost.get(k, 0)  # knock-out
+
     if max_cost:
-        costs = [np.sum([(kocost[k] if k in kocost else kicost.get(k, 0)) if v != 0 else 0 for k, v in m.items()]) for m in sd]
-        sd = [sd[i] for i in range(len(sd)) if costs[i] <= max_cost + 1e-8]
+        costs = [np.sum([itv_cost(k, v) for k, v in m.items()]) for m in sd]
+        keep = [i for i in range(len(sd)) if costs[i] <= max_cost + 1e-8]
+        sd = [sd[i] for i in keep]
         # sort strain designs by intervention costs
-        [s.update({'**cost**': c}) for s, c in zip(sd, costs)]
+        [sd[j].update({'**cost**': costs[i]}) for j, i in enumerate(keep)]
         sd.sort(key=lambda x: x.pop('**cost**'))
     return sd
 

--- a/straindesign/strainDesignProblem.py
+++ b/straindesign/strainDesignProblem.py
@@ -154,19 +154,26 @@ class SDProblem:
         for i in [i for i, x in enumerate(self.cost) if np.isnan(x)]:
             self.cost[i] = 0.0
         # Top 3 fixed rows of A_ineq (with the b_ineq values assembled just below):
-        #   row 0 (idx_row_maxcost):  -cost . z <= 0        -> total intervention cost >= 0
+        #   row 0 (idx_row_maxcost):  -cost . z <= inf      -> left open, see below
         #   row 1 (idx_row_mincost):   cost . z <= max_cost -> total intervention cost <= max_cost (budget cap)
         #   row 2 (idx_row_obj):       objective placeholder row (set later via fixObjective)
         # NOTE: the maxcost/mincost names are historical and read counter-intuitively -- row 0 is the
-        # >= 0 lower bracket, row 1 is the <= max_cost upper cap.
+        # lower bracket on total cost, row 1 is the <= max_cost upper cap.
+        # Row 0 used to read `total cost >= 0`. That is implied whenever every cost is
+        # non-negative, and z is binary, so the objective is bounded without it. Its only
+        # effect was on negative intervention costs, which are a documented way of forcing
+        # a reaction into every solution: give it a large negative cost and set max_cost
+        # accordingly, so any solution omitting it is unaffordable. The bracket made that
+        # infeasible by construction. The row is kept so that row indices -- and the
+        # z_map_constr_ineq columns aligned to them -- stay put.
         self.idx_row_maxcost = 0
         self.idx_row_mincost = 1
         self.idx_row_obj = 2
         self.A_ineq = sparse.csr_matrix([[-i for i in self.cost], self.cost, [0 for _ in range(self.num_z)]])
         if self.max_cost is None:
-            self.b_ineq = [0.0, float(np.sum(np.abs(self.cost))), np.inf]
+            self.b_ineq = [np.inf, float(np.sum(np.abs(self.cost))), np.inf]
         else:
-            self.b_ineq = [0.0, float(self.max_cost), np.inf]
+            self.b_ineq = [np.inf, float(self.max_cost), np.inf]
         self.z_map_constr_ineq = sparse.csc_matrix((numr, 3))
         self.lb = [1.0 if r.id in self.essential_kis else 0.0 for r in model.reactions]
         self.ub = [1.0 - float(i) for i in self.z_non_targetable]
@@ -199,7 +206,16 @@ class SDProblem:
 
         # Save continous part of MILP for easy strain design validation
         cont_vars = [i for i in range(0, self.A_ineq.shape[1]) if not i in self.idx_z]
-        self.cont_MILP = ContMILP(self.A_ineq[:, cont_vars], self.b_ineq.copy(), self.A_eq[:, cont_vars], self.b_eq.copy(),
+        # The three leading rows constrain z alone (both cost brackets and the objective
+        # placeholder). Once the z columns are dropped they read 0 <= rhs, which says
+        # nothing about the continuous system but turns every verification infeasible as
+        # soon as a cost is negative enough to make max_cost negative. Neutralise their
+        # right-hand sides here rather than dropping the rows, since z_map_constr_ineq
+        # columns are indexed by row position.
+        cont_b_ineq = self.b_ineq.copy()
+        for r in (self.idx_row_maxcost, self.idx_row_mincost, self.idx_row_obj):
+            cont_b_ineq[r] = np.inf
+        self.cont_MILP = ContMILP(self.A_ineq[:, cont_vars], cont_b_ineq, self.A_eq[:, cont_vars], self.b_eq.copy(),
                                   [self.lb[i] for i in cont_vars], [self.ub[i] for i in cont_vars], [self.c[i] for i in cont_vars],
                                   self.z_map_constr_ineq.tocoo(), self.z_map_constr_eq.tocoo(), self.z_map_vars[:, cont_vars].tocoo())
 


### PR DESCRIPTION
Three defects on the same path. Each is invisible alone, because a knockout-only problem never touches any of them. The first causes **silently wrong results with ordinary positive costs** and is independent of the other two.

## 1. `filter_sd_maxcost` charged a knock-in its knockout cost

`networktools.filter_sd_maxcost` priced an intervention by dict membership, `kocost` first:

```python
(kocost[k] if k in kocost else kicost.get(k, 0)) if v != 0 else 0
```

`SDProblem` prices it the other way round — knock-in wins over knockout (`strainDesignProblem.py:147,149-151`, where `ko_cost[i]` is nan-masked wherever `ki_cost[i]` is set). A reaction present in **both** dicts is therefore re-priced after the fact and the design is discarded.

The overlap is the normal case, not an edge case: `compute_strain_designs.py:476-477` defaults `uncmp_ko_cost` to *every* reaction id whenever the caller passes only `ki_cost`.

**This is not specific to negative costs.** On a four-reaction network with elementary flux vectors `{R1,R2,R4}` and `{R1,R3,R4}`, using `ko_cost={'R2': 50}`, `ki_cost={all: 1}`, `max_cost=3`, all positive:

| | designs |
|---|---|
| before | **1** — `[['R1','R3','R4']]` |
| after | **2** — both |

The MILP finds `{R1,R2,R4}` at cost 3; the filter re-prices it at 52 and drops it. Gene-based problems escape this because `uncmp_ko_cost` starts empty there, which is why no existing test catches it.

Fixed by dispatching on the sign of the design value (`+1` knock-in, `−1` knockout), the value semantics the function already documents. **Where `ki_cost` is empty the new expression is identical to the old term for term**, so knockout behaviour cannot change by construction.

The same expression also zipped the *filtered* designs against the *unfiltered* cost list when stamping `'**cost**'`, misaligning the labels and the resulting sort whenever the filter removed anything. Fixed alongside, since correct stamping is required once anything is filtered.

## 2. `cont_MILP` made `verify_sd` reject everything at a negative budget

`cont_MILP` keeps the three leading rows that constrain `z` alone. Stripped of their `z` columns they read `0 <= max_cost` — vacuous for a non-negative budget, but false for a negative one, so **every** design failed verification. Their right-hand sides are now neutralised in the continuous copy. The rows are kept rather than dropped, because `z_map_constr_ineq` columns are aligned to row positions.

## 3. Row 0 forbade a negative total cost

Row 0 asserted `total cost >= 0`. That is implied whenever costs are non-negative, and `z` is binary so the objective is bounded without it. Its only effect was to make negative costs infeasible by construction. Left open; the row itself is kept so row indices stay put.

## What this restores

Negative intervention costs as a way of forcing a reaction into every solution — give it a large negative cost and set `max_cost` so that omitting it is unaffordable, while the budget still bounds the rest:

| `cost(R2)` | `max_cost` | result |
|---|---|---|
| 1 | 3 | both EFVs |
| −100 | −97 | **`{R1,R2,R4}` only** — R2 forced, ≤3 other units |
| −100 | −98 | `{R1,R2,R4}` only |
| −100 | 0 | `{R1,R2,R4}` only, unbounded rest |

## Validation

- e_coli_core MCS (`growth >= 0.001`, `max_cost 3`): identical **353** designs, sizes {1:19, 2:111, 3:223}, compared as sets of frozensets — 0 missing, 0 extra
- Test suite: **368 passed, 2 skipped** (performance tests deselected)
- The positive-cost regression above verified against unmodified `main`

## Not addressed, flagged deliberately

- The deeper root cause of the overlap is `compute_strain_designs.py:476-477` defaulting `ko_cost` to all reactions. Fixing it there would shrink the MILP's knockout candidate set and change ordinary behaviour, so it is left alone.
- `strainDesignSolutions.py:219-243` resolves the same overlap by **summing** both dicts, so a reaction in both is double-counted in reported costs. Reporting only; does not affect design sets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RFtof9nZXFvCNoXz19po8C