### PR TITLE
Cheaper problem setup

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,12 @@ classifiers = [
     "Topic :: Scientific/Engineering :: Bio-Informatics",
 ]
 dependencies = [
-    "cobra",
+    # 0.32.0 cannot be imported on a default install: cobra/sampling/hopsy.py annotates a class
+    # attribute with `hopsy.Proposal` at class-definition time, but hopsy is an optional extra
+    # (`hopsy; extra == "chrr"`), so `import cobra` raises NameError. Excluding the one broken
+    # release is not a version bound in the sense of the note below -- drop it once cobra ships
+    # a fix. Upstream: https://pypi.org/project/cobra/0.32.0/
+    "cobra!=0.32.0",
     "scipy",
     "matplotlib",
     "psutil",

--- a/straindesign/compute_strain_designs.py
+++ b/straindesign/compute_strain_designs.py
@@ -508,9 +508,10 @@ def compute_strain_designs(model: Model, **kwargs: dict) -> SDSolutions:
             if _fba(model, constraints=m[CONSTRAINTS], solver=kwargs[SOLVER]).status == INFEASIBLE:
                 raise Exception("There is no feasible solution of the model under the given constraints.")
     logging.info('  Using ' + kwargs[SOLVER] + ' for solving LPs during preprocessing.')
-    with _silent_io():
-        orig_model = model
-        model = model.copy()
+    # No defensive copy here: between this point and `cmp_model = model.copy()` below, `model` is
+    # only read, and every mutation from then on goes to `cmp_model`. Copying twice cost a second
+    # full deepcopy of the model for nothing (0.8 s of a 3.6 s gap-filling call).
+    orig_model = model
     # FVA only ever *narrows* the problem handed to the MILP: it removes blocked reactions,
     # marks essential ones unknockable and pre-extracts size-1 MCS. The MILP finds the same
     # designs without any of it, so this is a speed/precomputation trade, not a semantic one.

--- a/straindesign/compute_strain_designs.py
+++ b/straindesign/compute_strain_designs.py
@@ -68,9 +68,13 @@ def _essentials_from_limits(flux_limits):
     ``flux_limits`` is an FVA result over the module's constrained polytope. Both bounds must share
     a sign and stay clear of zero, so the reaction carries flux in every point of the module.
     """
-    return {
-        reac_id for reac_id, limits in flux_limits.iterrows() if np.min(abs(limits)) > _ESSENTIALITY_TOL and np.prod(np.sign(limits)) > 0
-    }
+    # vectorised: iterrows() builds a Series per reaction and dominates this function on
+    # genome-scale models (measured 2.9 s over ~8200 reactions), while the test itself is a
+    # bound sweep
+    lo = flux_limits.iloc[:, 0].to_numpy(dtype=float)
+    hi = flux_limits.iloc[:, 1].to_numpy(dtype=float)
+    keep = (np.minimum(np.abs(lo), np.abs(hi)) > _ESSENTIALITY_TOL) & (np.sign(lo) * np.sign(hi) > 0)
+    return set(flux_limits.index[keep])
 
 
 def reduce_model_gprs(model, essential_reacs, gkis, gkos):
@@ -387,7 +391,8 @@ def compute_strain_designs(model: Model, **kwargs: dict) -> SDSolutions:
     """
     allowed_keys = {
         MODULES, SETUP, SOLVER, MAX_COST, MAX_SOLUTIONS, 'M', 'compress', 'gene_kos', KOCOST, KICOST, GKOCOST, GKICOST, REGCOST,
-        SOLUTION_APPROACH, 'advanced', 'use_scenario', T_LIMIT, SEED, MILP_THREADS, 'dump_preprocessed'
+        SOLUTION_APPROACH, 'advanced', 'use_scenario', T_LIMIT, SEED, MILP_THREADS, 'dump_preprocessed',
+        'skip_preprocessing_fvas'
     }
     logging.info('Preparing strain design computation.')
     if SETUP in kwargs:
@@ -506,6 +511,15 @@ def compute_strain_designs(model: Model, **kwargs: dict) -> SDSolutions:
     with _silent_io():
         orig_model = model
         model = model.copy()
+    # FVA only ever *narrows* the problem handed to the MILP: it removes blocked reactions,
+    # marks essential ones unknockable and pre-extracts size-1 MCS. The MILP finds the same
+    # designs without any of it, so this is a speed/precomputation trade, not a semantic one.
+    # It pays to skip when the model is large and the design problem is easy -- gap-filling a
+    # universe merge spends 252 s of 273 s in FVA for information the MILP does not need.
+    skip_fvas = bool(kwargs.pop('skip_preprocessing_fvas', False))
+    if skip_fvas:
+        logging.info('  Skipping preprocessing FVAs (skip_preprocessing_fvas).')
+
     _free = [k for k, v in list(uncmp_ko_cost.items()) + list(uncmp_ki_cost.items()) +
              list(locals().get('uncmp_gko_cost', {}).items()) + list(locals().get('uncmp_gki_cost', {}).items())
              if v == 0.0]
@@ -628,8 +642,8 @@ def compute_strain_designs(model: Model, **kwargs: dict) -> SDSolutions:
     logging.info('  FVA(s) to identify essential reactions.')
     essential_reacs = set()
     for m in sd_modules:
-        if m[MODULE_TYPE] != SUPPRESS:  # Essential reactions can only be determined from desired
-            # or opt-/robustknock modules
+        if m[MODULE_TYPE] != SUPPRESS and not skip_fvas:
+            # Essential reactions can only be determined from desired or opt-/robustknock modules
             flux_limits = fva(cmp_model, solver=kwargs[SOLVER], constraints=m[CONSTRAINTS], compress=False)
             essential_reacs.update(_essentials_from_limits(flux_limits))
     # remove ko-costs (and thus knockability) of essential reactions
@@ -733,7 +747,9 @@ def compute_strain_designs(model: Model, **kwargs: dict) -> SDSolutions:
     # one module's tighter ranges to the shared model could otherwise alter another module's polytope.
     fold_module_fva = (len(sd_modules) == 1 and sd_modules[0][MODULE_TYPE] in [SUPPRESS, PROTECT] and
                        sd_modules[0][INNER_OBJECTIVE] is None)
-    if fold_module_fva:
+    if skip_fvas:
+        pass
+    elif fold_module_fva:
         module = sd_modules[0]
         fold_scope = sorted(set(_fva_scope) | set(knockable_ids))
         flux_limits = bound_blocked_or_irrevers_fva(cmp_model,

--- a/straindesign/cplex_interface.py
+++ b/straindesign/cplex_interface.py
@@ -143,7 +143,9 @@ class Cplex_MILP_LP(Cplex):
         # add indicator constraints
         if not indic_constr == None:
             # cast variables and translate coefficient matrix A to right input format for CPLEX
-            A = [[[int(i) for i in list(a.indices)], [float(i) for i in list(a.data)]] for a in sparse.csr_matrix(indic_constr.A)]
+            _A = sparse.csr_matrix(indic_constr.A)
+            A = [[_A.indices[_A.indptr[i]:_A.indptr[i + 1]].astype(int).tolist(),
+                  _A.data[_A.indptr[i]:_A.indptr[i + 1]].astype(float).tolist()] for i in range(_A.shape[0])]
             b = [float(i) for i in indic_constr.b]
             sense = [str(i) for i in indic_constr.sense]
             indvar = [int(i) for i in indic_constr.binv]

--- a/straindesign/gurobi_interface.py
+++ b/straindesign/gurobi_interface.py
@@ -149,11 +149,14 @@ class Gurobi_MILP_LP(gp.Model):
         self._has_indicator_constr = indic_constr is not None
         if indic_constr is not None:
             A_csr = sparse.csr_matrix(indic_constr.A)
+            # LinExpr(coeffs, vars) builds the row in one call; quicksum walks it term by term in
+            # Python, which is where a genome-scale build spends most of its time
+            xvars = x.tolist()
             for i in range(len(indic_constr.sense)):
                 start, end = A_csr.indptr[i], A_csr.indptr[i + 1]
                 cols = A_csr.indices[start:end]
                 vals = A_csr.data[start:end]
-                lhs = gp.quicksum(float(val) * x[int(col)] for col, val in zip(cols, vals))
+                lhs = gp.LinExpr(vals.tolist(), [xvars[int(col)] for col in cols])
                 self.addGenConstrIndicator(x[indic_constr.binv[i]], bool(indic_constr.indicval[i]), lhs,
                                            '=' if indic_constr.sense[i] == 'E' else '<', indic_constr.b[i])
 

--- a/straindesign/lptools.py
+++ b/straindesign/lptools.py
@@ -22,7 +22,6 @@ from cobra.core import Solution
 from cobra.util import create_stoichiometric_matrix, linear_reaction_coefficients
 from cobra import Configuration
 from scipy import sparse
-from scipy.spatial import ConvexHull
 from math import log2
 from straindesign import MILP_LP, parse_constraints, parse_linexpr, lineqlist2mat, linexpr2dict, \
                          linexprdict2mat, SDPool, IndicatorConstraints, avail_solvers
@@ -34,12 +33,29 @@ from numpy import floor, sign, mod, nan, isnan, unique, inf, isinf, full, linspa
                   prod, array, mean, flip, ceil, floor, arctan2
 from contextlib import redirect_stdout, redirect_stderr
 from io import StringIO
-import matplotlib.pyplot as plt
-from matplotlib import use as set_matplotlib_backend
-from mpl_toolkits.mplot3d.art3d import Poly3DCollection
 import logging
 
 from straindesign.parse_constr import linexpr2mat, linexprdict2str
+
+# Plotting stack, bound on first use. Importing pyplot costs about half a second and
+# scipy.spatial another third of one, and only plot_flux_space and its helpers touch either --
+# computing a strain design should not pay for a plotting library it never calls.
+plt = None
+set_matplotlib_backend = None
+Poly3DCollection = None
+ConvexHull = None
+
+
+def _ensure_plotting():
+    """Import the plotting stack and bind it at module level."""
+    global plt, set_matplotlib_backend, Poly3DCollection, ConvexHull
+    if plt is not None:
+        return
+    import matplotlib.pyplot as _plt
+    from matplotlib import use as _use
+    from mpl_toolkits.mplot3d.art3d import Poly3DCollection as _poly3d
+    from scipy.spatial import ConvexHull as _hull
+    plt, set_matplotlib_backend, Poly3DCollection, ConvexHull = _plt, _use, _poly3d, _hull
 
 
 def model_objective(model):
@@ -1183,6 +1199,7 @@ def _trace_polytope_3d_rate(model, axes, constraints, solver):
     by optimizing along each face's outward normal. Converges when no face
     produces a new vertex.
     """
+    _ensure_plotting()
     coeffs = [axes[i][0] for i in range(3)]
     tol = 1e-8
 
@@ -1245,6 +1262,7 @@ def _hull_face_polygons(hull):
     Returns a list of faces, each face being a list of vertex indices
     ordered counterclockwise (viewed from outside).
     """
+    _ensure_plotting()
     from collections import defaultdict
     # Group simplices by face equation (rounded for coplanarity check)
     face_groups = defaultdict(set)
@@ -1434,6 +1452,7 @@ def plot_flux_space(model, axes, **kwargs) -> Tuple[list, list, list]:
             variable contains information about which datapoints need to be connected in triangles to
             render a closed surface. The last variable contains the matplotlib object.
     """
+    _ensure_plotting()
 
     cmp_model = kwargs.pop('cmp_model', None)
     cmp_map = kwargs.pop('cmp_map', None)

--- a/straindesign/lptools.py
+++ b/straindesign/lptools.py
@@ -42,6 +42,31 @@ import logging
 from straindesign.parse_constr import linexpr2mat, linexprdict2str
 
 
+def model_objective(model):
+    """The model's linear objective, without going through the solver where possible.
+
+    Returns the coefficients keyed by reaction id together with the optimisation direction.
+    A model built inside :func:`straindesign.networktools.suppress_lp_context` has no optlang
+    problem to ask -- there are no variables registered and reading ``model.objective`` raises
+    -- so the objective recorded on the model is used instead. On an ordinary model the live
+    objective is read once for the whole model rather than once per reaction.
+
+    Args:
+        model (cobra.Model):
+
+            The model to read the objective from.
+
+    Returns:
+        (Tuple[Dict, str]):
+
+        The objective coefficients by reaction id, and 'max' or 'min'.
+    """
+    recorded = getattr(model, '_suppressed_obj', None)
+    if recorded is not None:
+        return dict(recorded), getattr(model, '_suppressed_obj_direction', 'max')
+    return ({r.id: float(v) for r, v in linear_reaction_coefficients(model).items()}, model.objective_direction)
+
+
 def select_solver(solver=None, model=None) -> str:
     """Select a solver for subsequent MILP/LP computations
     
@@ -449,17 +474,15 @@ def fba(model, **kwargs) -> Solution:
     else:
         kwargs[CONSTRAINTS] = []
 
+    model_obj, model_obj_direction = model_objective(model)
     if 'obj' in kwargs and kwargs['obj'] is not None:
         if type(kwargs['obj']) is str:
             kwargs['obj'] = linexpr2dict(kwargs['obj'], reaction_ids)
         c = linexprdict2mat(kwargs['obj'], reaction_ids).toarray()[0].tolist()
     else:
-        # reaction.objective_coefficient re-reads the solver's objective expression once per
-        # reaction; linear_reaction_coefficients reads it once for the whole model
-        obj_coeffs = linear_reaction_coefficients(model)
-        c = [float(obj_coeffs.get(r, 0.0)) for r in model.reactions]
+        c = [model_obj.get(r.id, 0.0) for r in model.reactions]
 
-    if ('obj_sense' not in kwargs and model.objective_direction == 'max') or \
+    if ('obj_sense' not in kwargs and model_obj_direction == 'max') or \
        ('obj_sense' in kwargs and kwargs['obj_sense'] not in ['min','minimize']):
         obj_sense = 'maximize'
         c = [-i for i in c]
@@ -620,12 +643,13 @@ def slim_fba_via_cmp(model, cmp_model, cmp_map, **kwargs) -> float:
     # --- Map objective to compressed space ---
     # Build factor map: orig_id -> (cmp_id, cumulative_factor)
     # Only for reactions appearing in the objective (cheap).
+    model_obj, model_obj_direction = model_objective(model)
     if 'obj' in kwargs and kwargs['obj'] is not None:
         obj = kwargs['obj']
         if isinstance(obj, str):
             obj = linexpr2dict(obj, orig_reaction_ids)
     else:
-        obj = {r.id: r.objective_coefficient for r in model.reactions if r.objective_coefficient != 0}
+        obj = {r_id: v for r_id, v in model_obj.items() if v != 0}
 
     # Trace each objective reaction through compression
     obj_cmp = {}
@@ -646,7 +670,7 @@ def slim_fba_via_cmp(model, cmp_model, cmp_map, **kwargs) -> float:
     c = linexprdict2mat(obj_cmp, cmp_reaction_ids).toarray()[0].tolist()
 
     # --- Handle obj_sense ---
-    if ('obj_sense' not in kwargs and model.objective_direction == 'max') or \
+    if ('obj_sense' not in kwargs and model_obj_direction == 'max') or \
        ('obj_sense' in kwargs and kwargs['obj_sense'] not in ['min', 'minimize']):
         obj_sense = 'maximize'
         c = [-i for i in c]

--- a/straindesign/lptools.py
+++ b/straindesign/lptools.py
@@ -19,7 +19,7 @@
 """A collection of functions for the LP-based analysis of metabolic networks"""
 
 from cobra.core import Solution
-from cobra.util import create_stoichiometric_matrix
+from cobra.util import create_stoichiometric_matrix, linear_reaction_coefficients
 from cobra import Configuration
 from scipy import sparse
 from scipy.spatial import ConvexHull
@@ -454,7 +454,10 @@ def fba(model, **kwargs) -> Solution:
             kwargs['obj'] = linexpr2dict(kwargs['obj'], reaction_ids)
         c = linexprdict2mat(kwargs['obj'], reaction_ids).toarray()[0].tolist()
     else:
-        c = [i.objective_coefficient for i in model.reactions]
+        # reaction.objective_coefficient re-reads the solver's objective expression once per
+        # reaction; linear_reaction_coefficients reads it once for the whole model
+        obj_coeffs = linear_reaction_coefficients(model)
+        c = [float(obj_coeffs.get(r, 0.0)) for r in model.reactions]
 
     if ('obj_sense' not in kwargs and model.objective_direction == 'max') or \
        ('obj_sense' in kwargs and kwargs['obj_sense'] not in ['min','minimize']):

--- a/straindesign/networktools.py
+++ b/straindesign/networktools.py
@@ -401,6 +401,33 @@ def _is_lp_suppressed():
     return _ORIG_SLC is not None or _ORIG_SB is not None or _ORIG_OSLC is not None or len(_ORIG_COBRA) > 0
 
 
+def set_suppressed_objective(model, coefficients, direction='max'):
+    """Record a linear objective on a model whose solver was never populated.
+
+    ``model.objective = ...`` writes into the optlang problem, which is exactly what
+    :func:`suppress_lp_context` exists to avoid -- and on a model assembled inside that context
+    there are no variables to write to, so the objective is silently lost and later reads raise.
+    This records it on the model instead, where StrainDesign's LP tools look for it
+    (:func:`straindesign.lptools.model_objective`). Unlike the objective the context manager
+    captures for itself, this one outlives the context.
+
+    Args:
+        model (cobra.Model):
+
+            The model to record the objective on.
+
+        coefficients (dict):
+
+            Objective coefficients, keyed by reaction id.
+
+        direction (str): (Default: 'max')
+
+            'max' or 'min'.
+    """
+    model._suppressed_obj = {str(k): float(v) for k, v in coefficients.items()}
+    model._suppressed_obj_direction = direction
+
+
 @contextmanager
 def suppress_lp_context(model):
     """Context manager that suppresses all solver-touching operations.
@@ -414,13 +441,24 @@ def suppress_lp_context(model):
     """
     entered_here = not _is_lp_suppressed()
     if entered_here:
-        # Capture objective and reaction IDs before suppression (solver still live)
-        obj_dict = {}
-        for rxn in model.reactions:
+        # Capture objective and reaction IDs before suppression (solver still live). A model that
+        # already carries a recorded objective -- one built by set_suppressed_objective, whose
+        # solver was never populated -- keeps it: there is nothing live to re-read, and reading
+        # would either raise or quietly report no objective at all.
+        recorded = getattr(model, '_suppressed_obj', None)
+        if recorded is not None:
+            obj_dict = dict(recorded)
+        else:
+            obj_dict = {}
+            for rxn in model.reactions:
+                try:
+                    c = rxn.objective_coefficient
+                    if c != 0:
+                        obj_dict[rxn.id] = float(c)
+                except Exception:
+                    pass
             try:
-                c = rxn.objective_coefficient
-                if c != 0:
-                    obj_dict[rxn.id] = float(c)
+                model._suppressed_obj_direction = model.objective_direction
             except Exception:
                 pass
         _pre_ids = {r.id for r in model.reactions}
@@ -436,7 +474,9 @@ def suppress_lp_context(model):
             current_ids = {r.id for r in model.reactions}
             # Use the stored objective (compression may have updated it)
             final_obj = getattr(model, '_suppressed_obj', obj_dict)
-            if hasattr(model, '_suppressed_obj'):
+            if recorded is not None:
+                model._suppressed_obj = dict(final_obj)  # the record outlives the context
+            elif hasattr(model, '_suppressed_obj'):
                 del model._suppressed_obj
             if current_ids != _pre_ids:
                 if model.groups:

--- a/straindesign/scip_interface.py
+++ b/straindesign/scip_interface.py
@@ -131,22 +131,15 @@ class SCIP_MILP(pso.Model):
         self.trms = [list(x[i].terms.items())[0][0] for i in range(numvars)]
 
         self.constr = []
-        # add inequality constraints
-        ineqs = [self.addCons(pso.Expr() <= b_i, modifiable=True) for b_i in b_ineq]
-        for row, a_ineq in zip(ineqs, A_ineq):
-            X = [x[i] for i in a_ineq.indices]
-            for col, coeff in zip(X, a_ineq.data):
-                self.addConsCoeff(row, col, coeff)
-        self.constr += ineqs
-        # add equality constraints
-        eqs = [self.addCons(pso.Expr() == b_i, modifiable=True) for b_i in b_eq]
-        for row, a_eq in zip(eqs, A_eq):
-            X = [x[i] for i in a_eq.indices]
-            for col, coeff in zip(X, a_eq.data):
-                self.addConsCoeff(row, col, coeff)
-        self.constr += eqs
+        # Each row goes in as a single expression built from the terms cached above. Adding an
+        # empty row and then one addConsCoeff per nonzero costs a PySCIPOpt call per matrix
+        # entry, which at genome scale is hundreds of thousands of them. The rows stay
+        # modifiable because set_ineq_constraint() and the exclusion constraints edit them later.
+        self.constr += self._add_rows(A_ineq, b_ineq, '<=')
+        self.constr += self._add_rows(A_eq, b_eq, '==')
 
         self.setMinimize()
+
         # add indicator constraints
         if indic_constr is not None:
             for i in range(len(indic_constr.sense)):
@@ -205,9 +198,31 @@ class SCIP_MILP(pso.Model):
         # SCIP_PARAMEMPHASIS_PHASEIMPROVE= 8,        /**< improvement phase settings during 3-phase solving approach */
         # SCIP_PARAMEMPHASIS_PHASEPROOF  = 9         /**< proof phase settings during 3-phase solving approach */
 
+    def _add_rows(self, A, b, sense):
+        """Add the rows of A ~ b to the model, one expression per row.
+
+        Args:
+            A (sparse matrix): coefficient matrix, one row per constraint
+            b (list of float): right hand side
+            sense (str): '<=' or '=='
+
+        Returns:
+            (list): the constraint handles, in row order
+        """
+        A = sparse.csr_matrix(A)
+        indptr, indices, data = A.indptr, A.indices, A.data
+        rows = []
+        for i in range(A.shape[0]):
+            start, end = indptr[i], indptr[i + 1]
+            e = pso.scip.Expr({self.trms[j]: float(d) for j, d in zip(indices[start:end], data[start:end])})
+            rhs = float(b[i])
+            f = pso.scip.ExprCons(e, lhs=rhs, rhs=rhs) if sense == '==' else pso.scip.ExprCons(e, lhs=None, rhs=rhs)
+            rows.append(self.addCons(f, modifiable=True))
+        return rows
+
     def solve(self) -> Tuple[List, float, float]:
         """Solve the MILP
-        
+
         Example:
             sol_x, optim, status = scip.solve()
         
@@ -422,12 +437,7 @@ class SCIP_MILP(pso.Model):
                 The right hand side vector
         """
         self.freeTransform()
-        ineqs = [self.addCons(pso.Expr() <= b_i, modifiable=True) for b_i in b_ineq]
-        for row, a_ineq in zip(ineqs, A_ineq):
-            X = [self.vars[i] for i in a_ineq.indices]
-            for col, coeff in zip(X, a_ineq.data):
-                self.addConsCoeff(row, col, float(coeff))
-        self.constr += ineqs
+        self.constr += self._add_rows(A_ineq, b_ineq, '<=')
 
     def add_eq_constraints(self, A_eq, b_eq):
         """Add equality constraints to the model
@@ -444,12 +454,7 @@ class SCIP_MILP(pso.Model):
                 The right hand side vector
         """
         self.freeTransform()
-        eqs = [self.addCons(pso.Expr() == b_i, modifiable=True) for b_i in b_eq]
-        for row, a_eq in zip(eqs, A_eq):
-            X = [self.vars[i] for i in a_eq.indices]
-            for col, coeff in zip(X, a_eq.data):
-                self.addConsCoeff(row, col, float(coeff))
-        self.constr += eqs
+        self.constr += self._add_rows(A_eq, b_eq, '==')
 
     def set_ineq_constraint(self, idx, a_ineq, b_ineq):
         """Replace a specific inequality constraint

--- a/straindesign/strainDesignMILP.py
+++ b/straindesign/strainDesignMILP.py
@@ -324,19 +324,19 @@ class SDMILP(SDProblem, MILP_LP):
         """Verify computed strain design"""
         sols_orig = self._expand_z_to_orig(sols)
         valid = [False] * sols_orig.shape[0]
+        def _split(z_map, sol_row):
+            """Columns of z_map the solution switches off, and the complement."""
+            inactive = [col for z_i, col, sense in zip(z_map.row, z_map.col, z_map.data)
+                        if np.logical_xor(sol_row[z_i], sense == -1)]
+            keep = np.ones(z_map.shape[1], dtype=bool)
+            keep[inactive] = False
+            return inactive, np.nonzero(keep)[0].tolist()
+
         for i, sol in zip(range(sols_orig.shape[0]), sols_orig):
-            inactive_vars = [var for z_i,var,sense in \
-                            zip(self.cont_MILP.z_map_vars.row,self.cont_MILP.z_map_vars.col,self.cont_MILP.z_map_vars.data)\
-                            if np.logical_xor(sol[0,z_i],sense==-1)]
-            active_vars = [i for i in range(self.cont_MILP.z_map_vars.shape[1]) if i not in inactive_vars]
-            inactive_ineqs = [ineq for z_i,ineq,sense in \
-                            zip(self.cont_MILP.z_map_constr_ineq.row,self.cont_MILP.z_map_constr_ineq.col,self.cont_MILP.z_map_constr_ineq.data)\
-                            if np.logical_xor(sol[0,z_i],sense==-1) ]
-            active_ineqs = [i for i in range(self.cont_MILP.z_map_constr_ineq.shape[1]) if i not in inactive_ineqs]
-            inactive_eqs = [eq for z_i,eq,sense in \
-                            zip(self.cont_MILP.z_map_constr_eq.row,self.cont_MILP.z_map_constr_eq.col,self.cont_MILP.z_map_constr_eq.data)\
-                            if np.logical_xor(sol[0,z_i],sense==-1) ]
-            active_eqs = [i for i in range(self.cont_MILP.z_map_constr_eq.shape[1]) if i not in inactive_eqs]
+            sol_row = np.ravel(sol.toarray() if hasattr(sol, 'toarray') else np.asarray(sol))
+            inactive_vars, active_vars = _split(self.cont_MILP.z_map_vars, sol_row)
+            inactive_ineqs, active_ineqs = _split(self.cont_MILP.z_map_constr_ineq, sol_row)
+            inactive_eqs, active_eqs = _split(self.cont_MILP.z_map_constr_eq, sol_row)
 
             # Zeroing a variable whose bounds exclude zero contradicts that bound, so the
             # region is empty whatever the remaining system does. This has to be tested

--- a/straindesign/strainDesignProblem.py
+++ b/straindesign/strainDesignProblem.py
@@ -843,35 +843,33 @@ class SDProblem:
 
         _idxz = set(self.idx_z)  # O(1) membership in the scan below
         cont_vars = [i not in _idxz for i in range(0, numvars)]
-        M_lb = [self.lb[i] for i in np.nonzero(cont_vars)[0]]
-        M_ub = [self.ub[i] for i in np.nonzero(cont_vars)[0]]
+        _cont_idx = np.nonzero(cont_vars)[0]
+        M_lb = np.array([self.lb[i] for i in _cont_idx], dtype=float)
+        M_ub = np.array([self.ub[i] for i in _cont_idx], dtype=float)
         M_A = self.A_ineq[knockable_constr_ineq, :][:, cont_vars].tocsr()
 
         num_Ms = M_A.shape[0]
-        max_Ax = [np.nan] * num_Ms
 
         # max(a*x) from bounds: zero rows -> 0; single-variable rows -> coeff*(ub if coeff>0 else lb),
         # or +inf if that bound is infinite; multi-variable rows -> +inf (unbounded dual constraint).
-        n_zero = 0
-        n_single = 0
-        n_multi = 0
-        for i in range(num_Ms):
-            row = M_A.getrow(i)
-            nnz = row.nnz
-            if nnz == 0:
-                max_Ax[i] = 0.0
-                n_zero += 1
-            elif nnz == 1:
-                col_idx = row.indices[0]
-                coeff = row.data[0]
-                if coeff > 0:
-                    max_Ax[i] = coeff * M_ub[col_idx] if not isinf(M_ub[col_idx]) else np.inf
-                else:
-                    max_Ax[i] = coeff * M_lb[col_idx] if not isinf(M_lb[col_idx]) else np.inf
-                n_single += 1
-            else:
-                max_Ax[i] = np.inf
-                n_multi += 1
+        # Row arity comes from the index pointers, so this reads the whole matrix once instead of
+        # slicing out one row object per constraint.
+        _indptr = M_A.indptr
+        row_nnz = np.diff(_indptr)
+        max_Ax = np.full(num_Ms, np.inf)
+        max_Ax[row_nnz == 0] = 0.0
+        single = np.nonzero(row_nnz == 1)[0]
+        if single.size:
+            _at = _indptr[single]
+            col_idx = M_A.indices[_at]
+            coeff = M_A.data[_at]
+            bnd = np.where(coeff > 0, M_ub[col_idx], M_lb[col_idx])
+            # an infinite bound gives +inf whatever the coefficient's sign; zero it out first so
+            # the product never evaluates inf*0
+            max_Ax[single] = np.where(np.isinf(bnd), np.inf, coeff * np.where(np.isinf(bnd), 0.0, bnd))
+        n_zero = int(np.count_nonzero(row_nnz == 0))
+        n_single = int(single.size)
+        n_multi = num_Ms - n_zero - n_single
         logging.info('  Bounding MILP: %d constraints (%d zero, %d single-var, %d multi-var->indicator/M).' %
                      (num_Ms, n_zero, n_single, n_multi))
 
@@ -966,7 +964,11 @@ class SDProblem:
         #   where every first entry of a row is positive
         # - search for row duplicates
         # - delete one if their first row entry had the same sign, lump to equality if they had opposite signs
-        first_entry_A_ineq_sign = [np.sign(a.data[0]) if a.nnz > 0 else 0 for a in self.A_ineq]
+        _ineq_indptr = self.A_ineq.indptr
+        _ineq_nnz = np.diff(_ineq_indptr)
+        first_entry_A_ineq_sign = np.zeros(self.A_ineq.shape[0])
+        _nonempty = np.nonzero(_ineq_nnz)[0]
+        first_entry_A_ineq_sign[_nonempty] = np.sign(self.A_ineq.data[_ineq_indptr[_nonempty]])
         Ab_find_dupl = sparse.hstack((sparse.diags(first_entry_A_ineq_sign) * self.A_ineq, \
                                       sparse.coo_matrix(
                                           sparse.diags(first_entry_A_ineq_sign) * self.b_ineq).transpose(), \
@@ -978,9 +980,13 @@ class SDProblem:
         ident_rows = []  # duplicate rows as Tuple (i,j,k): first row, second row, positive or negative duplicate
         row_key = {}
         dupl_groups = {}
+        Ab_find_dupl.sort_indices()  # so a row's key does not depend on the order entries were stored in
+        _dupl_indptr = Ab_find_dupl.indptr
+        _dupl_indices = Ab_find_dupl.indices
+        _dupl_data = Ab_find_dupl.data
         for i in knockable_constr_ineq_ic:
-            row = Ab_find_dupl.getrow(i)
-            key = (row.indices.tobytes(), row.data.tobytes())
+            start, end = _dupl_indptr[i], _dupl_indptr[i + 1]
+            key = (_dupl_indices[start:end].tobytes(), _dupl_data[start:end].tobytes())
             row_key[i] = key
             dupl_groups.setdefault(key, []).append(i)
         for i in knockable_constr_ineq_ic:  # ascending
@@ -989,13 +995,17 @@ class SDProblem:
                     ident_rows += [(i, j, first_entry_A_ineq_sign[i] * first_entry_A_ineq_sign[j])]
         # replace two ineqs by one eq
         self.z_map_constr_ineq = self.z_map_constr_ineq.tocsc()
-        A_eq = sparse.csr_matrix((0, self.A_ineq.shape[1]))
-        z_eq = sparse.csc_matrix((self.num_z, 0))
-        b_eq = []
-        for j in [i for i in range(len(ident_rows)) if ident_rows[i][2] == -1]:
-            A_eq = sparse.vstack((A_eq, self.A_ineq[ident_rows[j][0]]))
-            b_eq += [self.b_ineq[ident_rows[j][0]]]
-            z_eq = sparse.hstack((z_eq, self.z_map_constr_ineq[:, ident_rows[j][0]]))
+        # gather the rows to lump in one slice each: stacking inside the loop rebuilds the whole
+        # matrix on every iteration
+        lump_rows = [ir[0] for ir in ident_rows if ir[2] == -1]
+        if lump_rows:
+            A_eq = self.A_ineq[lump_rows, :]
+            b_eq = [self.b_ineq[i] for i in lump_rows]
+            z_eq = self.z_map_constr_ineq[:, lump_rows]
+        else:
+            A_eq = sparse.csr_matrix((0, self.A_ineq.shape[1]))
+            z_eq = sparse.csc_matrix((self.num_z, 0))
+            b_eq = []
         # Add to global equality problem part
         knockable_constr_eq_ic = [i + len(self.b_eq) for i in range(len(b_eq))]
         self.A_eq = sparse.vstack((self.A_eq, A_eq), 'csr')
@@ -1007,9 +1017,11 @@ class SDProblem:
             remove_ineq = np.array([], 'int')
         else:
             remove_ineq = np.unique(np.hstack([[ir[0], ir[1]] if ir[2] == -1 else [ir[1]] for ir in ident_rows]))
-        keep_ineq = [i for i in range(self.A_ineq.shape[0]) if i not in remove_ineq]
-        knockable_constr_ineq_ic = [True if i in knockable_constr_ineq_ic else False for i in range(self.A_ineq.shape[0])]
-        knockable_constr_ineq_ic = np.nonzero([knockable_constr_ineq_ic[i] for i in keep_ineq])[0]
+        _remove = set(int(i) for i in remove_ineq)
+        _is_ic = np.zeros(self.A_ineq.shape[0], dtype=bool)
+        _is_ic[list(knockable_constr_ineq_ic)] = True
+        keep_ineq = [i for i in range(self.A_ineq.shape[0]) if i not in _remove]
+        knockable_constr_ineq_ic = np.nonzero(_is_ic[keep_ineq])[0]
         self.A_ineq = self.A_ineq[keep_ineq, :]
         self.b_ineq = [self.b_ineq[i] for i in keep_ineq]
         self.z_map_constr_ineq = self.z_map_constr_ineq[:, keep_ineq]
@@ -1030,10 +1042,12 @@ class SDProblem:
         self.indic_constr = IndicatorConstraints(ic_binv, ic_A, ic_b, ic_sense, ic_indicval)
 
         # b6. Remove knockable (in)equalities from static problem, as they are now indicator constraints
-        keep_ineq = [False if i in knockable_constr_ineq_ic else True for i in range(self.A_ineq.shape[0])]
+        _drop_ineq = set(int(i) for i in knockable_constr_ineq_ic)
+        _drop_eq = set(int(i) for i in knockable_constr_eq_ic)
+        keep_ineq = [i not in _drop_ineq for i in range(self.A_ineq.shape[0])]
         self.A_ineq = self.A_ineq[keep_ineq, :]
         self.b_ineq = [self.b_ineq[i] for i in range(len(keep_ineq)) if keep_ineq[i]]
-        keep_eq = [False if i in knockable_constr_eq_ic else True for i in range(self.A_eq.shape[0])]
+        keep_eq = [i not in _drop_eq for i in range(self.A_eq.shape[0])]
         self.A_eq = self.A_eq[keep_eq, :]
         self.b_eq = [self.b_eq[i] for i in range(len(keep_eq)) if keep_eq[i]]
 
@@ -1054,16 +1068,25 @@ class SDProblem:
         Aec = self.A_eq.tocsc() if self.A_eq.shape[0] else None
         budget_rows = {self.idx_row_maxcost, self.idx_row_mincost, self.idx_row_obj}
         z_with_ind = set(int(b) for b in self.indic_constr.binv) if self.indic_constr is not None else set()
+        # which columns carry a z-link: one pass over the stored entries rather than a column
+        # slice per binary
+        _is_budget = np.zeros(Aic.shape[0], dtype=bool)
+        for r in budget_rows:
+            if r is not None and 0 <= r < Aic.shape[0]:
+                _is_budget[r] = True
+        _col_of = np.repeat(np.arange(Aic.shape[1]), np.diff(Aic.indptr))
+        _links = np.zeros(Aic.shape[1], dtype=bool)
+        _links[_col_of[~_is_budget[Aic.indices] & (Aic.data != 0)]] = True
+        _links_eq = np.diff(Aec.indptr) > 0 if Aec is not None else np.zeros(Aic.shape[1], dtype=bool)
         n_free = 0
         for z in range(self.num_z):
             if self.z_non_targetable[z] or self.z_inverted[z] or self.lb[z] > 0 or self.ub[z] == 0:
                 continue
             if z in z_with_ind:
                 continue
-            col = Aic.getcol(z).tocoo()
-            if any((r not in budget_rows) and v != 0 for r, v in zip(col.row.tolist(), col.data.tolist())):
+            if _links[z]:
                 continue  # finite-M z-link -> controls a row
-            if Aec is not None and Aec.getcol(z).nnz:
+            if _links_eq[z]:
                 continue  # equality z-link
             self.ub[z] = 0.0
             n_free += 1

--- a/tests/test_02_lp_optimization.py
+++ b/tests/test_02_lp_optimization.py
@@ -162,3 +162,29 @@ def test_fva_wrapper_matches_speedy(ecoli_core, fva_solver):
 def test_fva_all_reactions_present(ecoli_core, res_compressed):
     """FVA result must contain every reaction in the model."""
     assert set(res_compressed.index) == {r.id for r in ecoli_core.reactions}
+
+
+def test_indicator_is_one_directional(curr_solver):
+    """An indicator gates its row in one direction only.
+
+    z = indicval enforces the row; the other value leaves it out entirely, and in particular
+    does NOT force the row to be violated. Minimal cut sets rely on exactly this: a knockout
+    must be able to drop a constraint, but a constraint that happens to hold must not force
+    the knockout binary back to zero. All backends have to agree on it.
+    """
+    from scipy import sparse
+
+    def max_v(indicval, fix_z):
+        ic = sd.IndicatorConstraints([1], sparse.csr_matrix([[1.0, 0.0]]), [0.0], 'L', [indicval])
+        milp = sd.MILP_LP(c=[-1.0, 0.0],
+                          A_ineq=sparse.csr_matrix((0, 2)), b_ineq=[],
+                          A_eq=sparse.csr_matrix((0, 2)), b_eq=[],
+                          lb=[0.0, float(fix_z)], ub=[10.0, float(fix_z)],
+                          vtype='CB', indic_constr=ic, solver=curr_solver)
+        x, _, status = milp.solve()
+        assert status == sd.names.OPTIMAL
+        return x[0]
+
+    for indicval in (0, 1):
+        assert max_v(indicval, indicval) == pytest.approx(0.0)       # row enforced: v <= 0
+        assert max_v(indicval, 1 - indicval) == pytest.approx(10.0)  # row absent: v free

--- a/tests/test_05_straindesign.py
+++ b/tests/test_05_straindesign.py
@@ -620,3 +620,54 @@ def test_trim_preserves_binaries_outside_the_intervention_block(curr_solver):
     if seen.get('keyed'):
         assert seen['binv'][0] == len(seen['vtype']) - 1
         assert seen['vtype'][seen['binv'][0]] == 'B'
+
+
+@pytest.mark.parametrize('gene_kos', [False, True])
+def test_caller_model_is_left_untouched(curr_solver, model_gpr, gene_kos):
+    """compute_strain_designs must not modify the model it was handed.
+
+    Preprocessing works on its own copy: compression lumps reactions, the GPR extension adds
+    pseudo-reactions and the FVAs retighten bounds, none of which the caller asked for. Only
+    one copy is taken, so this is the invariant that keeps that safe.
+    """
+
+    def snapshot(m):
+        return ([r.id for r in m.reactions], [g.id for g in m.genes], [x.id for x in m.metabolites],
+                [(r.lower_bound, r.upper_bound) for r in m.reactions],
+                [r.gene_reaction_rule for r in m.reactions],
+                {r.id: r.objective_coefficient for r in m.reactions if r.objective_coefficient != 0},
+                [sorted((x.id, v) for x, v in r.metabolites.items()) for r in m.reactions])
+
+    before = snapshot(model_gpr)
+    sd.compute_strain_designs(model_gpr,
+                              sd_modules=[sd.SDModule(model_gpr, SUPPRESS, constraints=['r_bm >= 0.5'])],
+                              max_cost=2, max_solutions=3, solution_approach=POPULATE,
+                              gene_kos=gene_kos, compress=True, solver=curr_solver, seed=1)
+    assert snapshot(model_gpr) == before
+
+
+def test_objective_survives_a_suppressed_build(curr_solver, model_gpr):
+    """A model assembled under suppression carries its objective outside the solver.
+
+    ``model.objective = ...`` writes into the optlang problem, so a model built inside
+    suppress_lp_context -- which is the point of the context -- would silently lose it and
+    raise on the next read. set_suppressed_objective records it where the LP tools look.
+    """
+    import cobra
+    from straindesign.networktools import suppress_lp_context, set_suppressed_objective
+    from straindesign.lptools import model_objective
+
+    reference = sd.fba(model_gpr, obj={'r_bm': 1.0}, obj_sense='maximize', solver=curr_solver)
+
+    with suppress_lp_context(cobra.Model('shell')):
+        bare = cobra.Model('bare')
+        bare.add_metabolites([cobra.Metabolite(m.id) for m in model_gpr.metabolites])
+        bare.add_reactions([cobra.Reaction(r.id) for r in model_gpr.reactions])
+        for r in model_gpr.reactions:
+            new = bare.reactions.get_by_id(r.id)
+            new.add_metabolites({m.id: v for m, v in r.metabolites.items()})
+            new.bounds = r.bounds
+        set_suppressed_objective(bare, {'r_bm': 1.0}, 'max')
+
+    assert model_objective(bare) == ({'r_bm': 1.0}, 'max')
+    assert sd.fba(bare, solver=curr_solver).objective_value == pytest.approx(reference.objective_value)


### PR DESCRIPTION
Setup-side costs found while profiling StrainDesign as a gap-filling backend for CarveMe.
None of it changes what is computed; it is all work that was being done one element at a
time. Two bugs turned up on the way and are fixed here too.

## Cheaper setup

**`skip_preprocessing_fvas`** (opt-in, default off). The preprocessing FVAs only *narrow* the
problem handed to the MILP: they drop blocked reactions, mark essential ones unknockable and
pre-extract size-1 cut sets. The MILP finds the same designs without any of it, so this is a
precomputation trade rather than a semantic one, and it does not pay when the model is large
and the design problem is easy. The essentiality sweep that follows is now vectorised.

**`link_z` reads its matrices whole.** It pulled out one row object per constraint, grew
`A_eq`/`z_eq` by restacking them inside a loop (quadratic in the lumped rows), and tested row
membership against lists and arrays with `in` (quadratic in the constraints). Each now reads
the index pointers once.

**Solver rows go in one call each.** Gurobi built every indicator constraint with a
`quicksum` over a generator; SCIP called `addConsCoeff` once per matrix entry for every row in
the problem. `LinExpr(coeffs, vars)` and `Expr({term: coeff})` take a whole row at once. CPLEX
already batched through `add_batch`; only its row extraction was per-row.

**One copy of the model, not two.** `compute_strain_designs` copied defensively and then
copied again for preprocessing. Between the two the model is only read, and every mutation
from there on goes to `cmp_model`.

**`verify_sd`** built three index complements per design as
`[i for i in range(n) if i not in inactive]` against a list, and re-read the solution row one
sparse entry at a time. Now a boolean mask.

**The plotting stack is imported on first use.** `lptools` pulled in `matplotlib.pyplot`,
`mpl_toolkits` and `scipy.spatial` at module level, so every `import straindesign` paid for a
plotting library whether or not anything was plotted.

## Two fixes

**A model built under suppression lost its objective.** `suppress_lp_context` exists so that
assembling a model pushes nothing into optlang -- but that means `model.objective = ...` has
no variables to write to. The objective was dropped without a word, and the next read raised
`KeyError` out of the optlang container rather than reporting an empty objective.
`set_suppressed_objective` records it on the model and `model_objective` reads it from there
when present, from the live solver otherwise.

**`fba` no longer needs a live optlang problem.** It read both the objective coefficients and
the direction through the solver, the coefficients once per reaction. A model whose solver was
never populated now runs through `fba` unchanged -- checked against reframed on a CarveMe
universe merge, same objective value to six digits.

## Numbers

| | before | after |
|---|---|---|
| iML1515 gene-MCS MILP setup | 2.71 s | **0.54 s** |
| Gurobi build, 2000 indicators | 2.16 s | **0.07 s** |
| `import straindesign` | 1.82 s | **1.45 s** |
| CarveMe gap-fill against the bacterial universe | 264 s | **2.7 s** |

The last row is the whole chain including `skip_preprocessing_fvas` and a change on the
CarveMe side; the rest are this branch alone, at identical variable and constraint counts.

## Checks

- `pytest tests/` — 426 passed, 7 skipped
- design-identity gate on coned models: e_coli_core **455**, iML1515 **393**; design sets
  bit-identical to the pre-change runs
- e_coli_core under SCIP: 455, sets identical to Gurobi's
- new tests pin three invariants: indicator semantics across all four backends, that
  `compute_strain_designs` returns the caller's model untouched, and that an objective
  recorded under suppression survives and drives `fba`

On indicators specifically: they hold in **one direction only**. `z = indicval` enforces the
row; the other value drops it and must not force the row to be violated. Cut sets depend on
that asymmetry -- a knockout must be able to relax a constraint, while a constraint that
happens to hold must not force the knockout binary back to zero. All four backends agree.