### PR TITLE
Exact-nullspace bigint input, pre-compression blocked pinning, and honest FVA statuses

### DIFF
--- a/straindesign/compression.py
+++ b/straindesign/compression.py
@@ -169,15 +169,16 @@ class RationalMatrix:
             for c in range(cols):
                 val = arr[r, c]
                 if val != 0:
-                    frac = float_to_fraction(val, max_precision, max_denom)
+                    if isinstance(val, (Fraction, int, np.integer)):
+                        frac = Fraction(val)
+                    else:
+                        frac = float_to_fraction(val, max_precision, max_denom)
                     row_idx.append(r)
                     col_idx.append(c)
                     num_data.append(frac.numerator)
                     den_data.append(frac.denominator)
 
-        num_sparse = csr_matrix((num_data, (row_idx, col_idx)), shape=(rows, cols), dtype=np.int64)
-        den_sparse = csr_matrix((den_data, (row_idx, col_idx)), shape=(rows, cols), dtype=np.int64)
-        return cls._from_sparse(num_sparse, den_sparse)
+        return cls._build_from_sparse_data(row_idx, col_idx, num_data, den_data, rows, cols)
 
     @classmethod
     def from_cobra_model(cls, model, max_precision: int = 6, max_denom: int = 100) -> 'RationalMatrix':
@@ -206,9 +207,27 @@ class RationalMatrix:
                     num_data.append(frac.numerator)
                     den_data.append(frac.denominator)
 
-        num_sparse = csr_matrix((num_data, (row_idx, col_idx)), shape=(num_mets, num_rxns), dtype=np.int64)
-        den_sparse = csr_matrix((den_data, (row_idx, col_idx)), shape=(num_mets, num_rxns), dtype=np.int64)
-        return cls._from_sparse(num_sparse, den_sparse)
+        return cls._build_from_sparse_data(row_idx, col_idx, num_data, den_data, num_mets, num_rxns)
+
+    @classmethod
+    def from_fractions(cls, entries, shape: Tuple[int, int]) -> 'RationalMatrix':
+        """Build from exact entries ``(row, col, value)``, where value is a Fraction or an int.
+
+        Values of unlimited size are accepted; storage ratchets to arbitrary precision only when
+        the int64 sparse representation cannot hold them.
+        """
+        rows, cols, nums, dens = [], [], [], []
+        for r, c, v in entries:
+            frac = v if isinstance(v, Fraction) else Fraction(v)
+            if frac == 0:
+                continue
+            if not (0 <= r < shape[0] and 0 <= c < shape[1]):
+                raise IndexError(f"entry ({r}, {c}) outside shape {shape}")
+            rows.append(int(r))
+            cols.append(int(c))
+            nums.append(frac.numerator)
+            dens.append(frac.denominator)
+        return cls._build_from_sparse_data(rows, cols, nums, dens, shape[0], shape[1])
 
     @classmethod
     def _build_from_sparse_data(cls, row_indices: List[int], col_indices: List[int], numerators: List[int], denominators: List[int],
@@ -232,6 +251,47 @@ class RationalMatrix:
         result._dict_frac = dic
         return result
 
+    # Exact access, independent of which store backs the matrix
+
+    def _require_sparse_store(self, op: str) -> None:
+        if self._dict_frac is not None:
+            raise NotImplementedError(
+                f"{op} is not available on a big-integer RationalMatrix; its coefficients exceed "
+                "int64 and are held as exact Fractions. Use nullspace()/basic_columns(), or "
+                "to_coo_exact() to export.")
+
+    def _iter_row_fractions(self) -> Iterator[Tuple[int, Dict[int, Fraction]]]:
+        """Yield (row, {col: Fraction}) for every non-empty row."""
+        if self._dict_frac is not None:
+            for r, cd in self._dict_frac.items():
+                row = {c: v for c, v in cd.items() if v}
+                if row:
+                    yield int(r), row
+            return
+        num_csr = self._num_sparse.tocsr()
+        den_csr = self._den_sparse.tocsr()
+        for r in range(self._rows):
+            start, end = num_csr.indptr[r], num_csr.indptr[r + 1]
+            row = {}
+            for i in range(start, end):
+                num = int(num_csr.data[i])
+                if num == 0:
+                    continue
+                den = int(den_csr.data[i]) or 1
+                row[int(num_csr.indices[i])] = Fraction(num, den)
+            if row:
+                yield r, row
+
+    def _nnz_per_column(self) -> np.ndarray:
+        counts = np.zeros(self._cols, dtype=np.int64)
+        if self._dict_frac is not None:
+            for cd in self._dict_frac.values():
+                for c, v in cd.items():
+                    if v:
+                        counts[c] += 1
+            return counts
+        return np.diff(self._num_sparse.tocsc().indptr)
+
     # Size queries
 
     def get_row_count(self) -> int:
@@ -244,6 +304,7 @@ class RationalMatrix:
 
     def iter_column_fractions(self, col: int) -> Iterator[Tuple[int, Fraction]]:
         """Iterate over non-zero entries in column as (row, Fraction) pairs."""
+        self._require_sparse_store('iter_column_fractions')
         if self._csc_cache is None:
             self._csc_cache = self._num_sparse.tocsc()
             self._den_csc_cache = self._den_sparse.tocsc()
@@ -260,6 +321,7 @@ class RationalMatrix:
 
     def get_signum(self, row: int, col: int) -> int:
         """Return sign of element: -1, 0, or 1."""
+        self._require_sparse_store('get_signum')
         num = self._num_sparse[row, col]
         if num > 0:
             return 1
@@ -271,6 +333,7 @@ class RationalMatrix:
 
     def begin_batch_edit(self):
         """Enter batch edit mode - delays cache invalidation."""
+        self._require_sparse_store('begin_batch_edit')
         self._batch_mode = True
         self._num_sparse = self._num_sparse.tolil()
         self._den_sparse = self._den_sparse.tolil()
@@ -286,16 +349,19 @@ class RationalMatrix:
 
     def clone(self) -> 'RationalMatrix':
         """Create a deep copy."""
+        self._require_sparse_store('clone')
         return RationalMatrix._from_sparse(self._num_sparse.copy(), self._den_sparse.copy())
 
     def submatrix(self, rows: int, cols: int) -> 'RationalMatrix':
         """Extract top-left submatrix of given dimensions."""
+        self._require_sparse_store('submatrix')
         num_sub = self._num_sparse[:rows, :cols].copy()
         den_sub = self._den_sparse[:rows, :cols].copy()
         return RationalMatrix._from_sparse(num_sub, den_sub)
 
     def remove_rows(self, keep_indices: List[int]) -> None:
         """Keep only the specified rows."""
+        self._require_sparse_store('remove_rows')
         keep = np.array(keep_indices, dtype=np.intp)
         self._num_sparse = self._num_sparse[keep, :]
         self._den_sparse = self._den_sparse[keep, :]
@@ -304,6 +370,7 @@ class RationalMatrix:
 
     def remove_columns(self, keep_indices: List[int]) -> None:
         """Keep only the specified columns."""
+        self._require_sparse_store('remove_columns')
         keep = np.array(keep_indices, dtype=np.intp)
         self._num_sparse = self._num_sparse[:, keep]
         self._den_sparse = self._den_sparse[:, keep]
@@ -531,7 +598,7 @@ def _rref_integer_sparse(rm: RationalMatrix) -> Tuple[Dict[int, Dict[int, int]],
 
     # Column sorting: sparse columns first
     # col_order[sorted_pos] = original_col
-    nnz_per_col = np.diff(rm._num_sparse.tocsc().indptr)
+    nnz_per_col = rm._nnz_per_column()
     col_order = np.argsort(nnz_per_col, kind='stable').tolist()
     col_inverse = [0] * cols
     for sorted_pos, orig_col in enumerate(col_order):
@@ -539,26 +606,12 @@ def _rref_integer_sparse(rm: RationalMatrix) -> Tuple[Dict[int, Dict[int, int]],
 
     # Convert to integer matrix (scale each row by LCM of denominators)
     # Store column indices in sorted space
-    num_csr = rm._num_sparse.tocsr()
-    den_csr = rm._den_sparse.tocsr()
-
     data: Dict[int, Dict[int, int]] = {}
-    for r in range(rows):
-        start, end = num_csr.indptr[r], num_csr.indptr[r + 1]
-        if start == end:
-            continue
-
-        # Compute row LCM of denominators
-        row_dens = [int(den_csr.data[i]) for i in range(start, end) if den_csr.data[i] != 0]
-        row_lcm = reduce(lcm, row_dens, 1) if row_dens else 1
-
-        # Scale numerators; store using sorted column index
+    for r, row_fracs in rm._iter_row_fractions():
+        row_lcm = reduce(lcm, (f.denominator for f in row_fracs.values()), 1)
         row_data = {}
-        for i in range(start, end):
-            num = int(num_csr.data[i])
-            den = int(den_csr.data[i]) if den_csr.data[i] != 0 else 1
-            orig_col = int(num_csr.indices[i])
-            scaled = num * (row_lcm // den)
+        for orig_col, frac in row_fracs.items():
+            scaled = frac.numerator * (row_lcm // frac.denominator)
             if scaled != 0:
                 row_data[col_inverse[orig_col]] = scaled
         if row_data:
@@ -811,8 +864,10 @@ def sparse_nullspace(matrix):
 
     Parameters
     ----------
-    matrix : scipy.sparse matrix, numpy.ndarray, or RationalMatrix
+    matrix : scipy.sparse matrix, numpy.ndarray, RationalMatrix, or ExactCOO
         Input with integer or rational entries. Floats are converted to nearby rationals.
+        Entries too large for signed 64-bit integers are accepted through RationalMatrix
+        (see ``RationalMatrix.from_fractions``) or ExactCOO, which scipy sparse cannot hold.
 
     Returns
     -------
@@ -826,6 +881,10 @@ def sparse_nullspace(matrix):
     """
     if isinstance(matrix, RationalMatrix):
         rm = matrix
+    elif isinstance(matrix, ExactCOO):
+        rm = RationalMatrix.from_fractions(
+            ((r, c, Fraction(int(v), int(matrix.denom))) for r, c, v in zip(matrix.rows, matrix.cols, matrix.data)),
+            matrix.shape)
     elif sparse.issparse(matrix):
         A = matrix.tocsr()
         if np.issubdtype(A.dtype, np.integer):

--- a/straindesign/speedy_fva.py
+++ b/straindesign/speedy_fva.py
@@ -78,6 +78,22 @@ _PARALLEL_PHASE2_MIN = 4000
 # ---------------------------------------------------------------------------
 
 
+def _pin_structurally_blocked(model) -> int:
+    """Fix reactions the structural sweep proves blocked to (0,0), in place.
+
+    `remove_blocked_reactions` filters on bounds and detects nothing itself, so without this it
+    has nothing to remove on a normally-bounded model.
+    """
+    af, ar = _rev_structural_sweep(model)
+    n = 0
+    for r in model.reactions:
+        if not af[r.id] and not ar[r.id] and (r.lower_bound, r.upper_bound) != (0.0, 0.0):
+            r.lower_bound = 0.0
+            r.upper_bound = 0.0
+            n += 1
+    return n
+
+
 def _compress_for_fva(model):
     """Copy and compress model for FVA (single-pass coupled compression + conservation removal).
 
@@ -96,6 +112,7 @@ def _compress_for_fva(model):
         # iML1515) and attaches a backend-free carrier.  Safe because speedy_fva builds its own
         # MILP_LP and the compression pipeline is solver-independent.
         cmp_model = model.copy()
+        _pin_structurally_blocked(cmp_model)
         remove_blocked_reactions(cmp_model)
         stoichmat_coeff_to_fraction(cmp_model)
         n_before = len(cmp_model.reactions)
@@ -423,6 +440,7 @@ def speedy_fva(model, **kwargs):
 
     # Stats
     lps_solved = 0
+    unresolved_bounds = []
     total_bound_resolved = 0
     t_solve = 0.0
     tol_bound = 1e-9
@@ -464,33 +482,11 @@ def speedy_fva(model, **kwargs):
         total_bound_resolved += int(newly_max.sum())
 
     if precheck:
-        # 1b: min(sum(|x|)) scan — pushes reactions toward zero
-        # Effective for resolving lb=0 / ub=0 bounds in one shot.
         scan_lp, n_scan = _build_abssum_lp(A_eq, b_eq, A_ineq, b_ineq, lb, ub, solver)
         scan_lp.set_lp_method(LP_METHOD_DUAL)
         n_ext = len(scan_lp.c)
 
-        t0 = _time.perf_counter()
-        x_list_scan, _, scan_status = scan_lp.solve()
-        t_solve += _time.perf_counter() - t0
-        lps_solved += 1
-        resolved_absmin = 0
-
-        if scan_status == OPTIMAL:
-            x_scan = np.array(x_list_scan[:n_scan], dtype=np.float64)
-            before = int(res_max.sum() + res_min.sum())
-            _bound_scan(x_scan)
-
-            np.maximum(incumbent_max, x_scan, out=incumbent_max)
-            np.minimum(incumbent_min, x_scan, out=incumbent_min)
-            resolved_absmin = int(res_max.sum() + res_min.sum()) - before
-
-        if verbose:
-            n_done_iter = int(res_max.sum() + res_min.sum())
-            logging.debug(f"  Phase 1 min|x|: +{resolved_absmin} "
-                          f"({n_done_iter}/{2*n_orig} resolved)")
-
-        # 1c: Iterative push-to-bounds — directed per-reaction objectives
+        # 1b: Iterative push-to-bounds — directed per-reaction objectives
         # Push unresolved-max reactions toward ub, unresolved-min toward lb.
         # Dual simplex warm-start makes re-optimization nearly free.
         push_iter = 0
@@ -622,13 +618,19 @@ def speedy_fva(model, **kwargs):
         # Collect parallel results
         for j in range(n_orig):
             i_max = 2 * j
-            if not res_max[j] and not np.isnan(x_par[i_max]):
-                res_max[j] = True
-                incumbent_max[j] = -x_par[i_max]
+            if not res_max[j]:
+                if np.isnan(x_par[i_max]):
+                    unresolved_bounds.append((reaction_ids[j], 1, 'nan'))
+                else:
+                    res_max[j] = True
+                    incumbent_max[j] = -x_par[i_max]
             i_min = 2 * j + 1
-            if not res_min[j] and not np.isnan(x_par[i_min]):
-                res_min[j] = True
-                incumbent_min[j] = x_par[i_min]
+            if not res_min[j]:
+                if np.isnan(x_par[i_min]):
+                    unresolved_bounds.append((reaction_ids[j], -1, 'nan'))
+                else:
+                    res_min[j] = True
+                    incumbent_min[j] = x_par[i_min]
 
     elif n_remaining > 0:
         # Sequential dispatch — simple loop, no hub-first, no dual check
@@ -654,21 +656,28 @@ def speedy_fva(model, **kwargs):
                     _rebuild_lp()
 
                 sig = -direction
-                if prev_col < 0 or prev_col == j:
-                    C = [[j, float(sig)]]
-                else:
-                    C = [[j, float(sig)], [prev_col, 0.0]]
-                if solver in ('cplex', 'gurobi'):
-                    lp.backend.set_objective_idx(C)
-                else:
-                    lp.set_objective_idx(C)
-                prev_col = j
+                for attempt in range(_MAX_STATUS_RETRIES + 1):
+                    if prev_col < 0 or prev_col == j:
+                        C = [[j, float(sig)]]
+                    else:
+                        C = [[j, float(sig)], [prev_col, 0.0]]
+                    if solver in ('cplex', 'gurobi'):
+                        lp.backend.set_objective_idx(C)
+                    else:
+                        lp.set_objective_idx(C)
+                    prev_col = j
 
-                t0 = _time.perf_counter()
-                x_list, obj_val, status = lp.solve()
-                t_solve += _time.perf_counter() - t0
-                lps_solved += 1
-                seq_count += 1
+                    t0 = _time.perf_counter()
+                    x_list, obj_val, status = lp.solve()
+                    t_solve += _time.perf_counter() - t0
+                    lps_solved += 1
+                    seq_count += 1
+
+                    # Feasibility was established once at setup and only the objective changes
+                    # here, so a non-optimal status is a solver artifact, not an answer.
+                    if status in (OPTIMAL, UNBOUNDED) or attempt == _MAX_STATUS_RETRIES:
+                        break
+                    _rebuild_lp()
 
                 if status == UNBOUNDED:
                     if direction == 1:
@@ -679,10 +688,13 @@ def speedy_fva(model, **kwargs):
                         incumbent_min[j] = -np.inf
                     continue
                 elif status != OPTIMAL:
+                    unresolved_bounds.append((reaction_ids[j], direction, status))
                     if direction == 1:
                         res_max[j] = True
+                        incumbent_max[j] = nan
                     else:
                         res_min[j] = True
+                        incumbent_min[j] = nan
                     continue
 
                 # Guard: LP optimum must not be worse than incumbent
@@ -727,6 +739,12 @@ def speedy_fva(model, **kwargs):
                     np.maximum(incumbent_max, x_arr, out=incumbent_max)
                     np.minimum(incumbent_min, x_arr, out=incumbent_min)
                     _bound_scan(x_arr)
+
+    if unresolved_bounds:
+        logging.warning(f"speedy_fva: {len(unresolved_bounds)} of {2*n_orig} bounds left unresolved after "
+                        f"{_MAX_STATUS_RETRIES} retries (solver '{solver}' reported "
+                        f"{sorted({st for _, _, st in unresolved_bounds})}); reported as NaN. "
+                        f"First: {unresolved_bounds[0][0]}")
 
     # ------------------------------------------------------------------
     # Assemble results
@@ -778,6 +796,7 @@ def speedy_fva(model, **kwargs):
 _REV_SCAN_TOL = 1e-3  # co-option certifies only on flux comfortably above solver noise
 _REV_REBUILD_EVERY = 200
 _ZERO_SNAP = 1e-11  # |flux| below this is solver noise, not a direction; 0 disables snapping
+_MAX_STATUS_RETRIES = 2  # fresh-LP retries before a bound is reported unresolved
 _DEGEN_TOL = 1e-6  # warm-start guard: fresh optimum must not fall below a known-achievable incumbent
 
 

--- a/tests/test_07_compression.py
+++ b/tests/test_07_compression.py
@@ -258,3 +258,90 @@ def test_mcs_e_coli_core():
         solver=solver,
     )
     assert len(sols.reaction_sd) == 455, (f"Expected 455 MCS for e_coli_core, got {len(sols.reaction_sd)}")
+
+
+# =============================================================================
+# Exact nullspace: arbitrary-precision input
+# =============================================================================
+
+
+def _kernel_columns(K):
+    """Kernel columns as {col: {row: Fraction}}, for either return type."""
+    from collections import defaultdict
+    cols = defaultdict(dict)
+    if isinstance(K, sd.ExactCOO):
+        for r, c, v in zip(K.rows, K.cols, K.data):
+            cols[int(c)][int(r)] = Fraction(int(v), int(K.denom))
+        return cols, K.shape
+    A = K.tocoo()
+    for r, c, v in zip(A.row, A.col, A.data):
+        cols[int(c)][int(r)] = Fraction(int(v))
+    return cols, A.shape
+
+
+def _assert_kernel_exact(entries, shape, K):
+    cols, kshape = _kernel_columns(K)
+    assert kshape[0] == shape[1]
+    rows = {}
+    for r, c, v in entries:
+        rows.setdefault(r, {})[c] = v
+    for j in range(kshape[1]):
+        kj = cols[j]
+        assert kj, f"kernel column {j} is empty"
+        for row in rows.values():
+            assert sum(v * kj.get(c, 0) for c, v in row.items()) == 0
+
+
+def test_rational_matrix_input_stays_int64_when_it_fits():
+    entries = [(0, 0, Fraction(1)), (0, 1, Fraction(-2)), (1, 1, Fraction(3)), (1, 2, Fraction(-1))]
+    rm = sd.RationalMatrix.from_fractions(entries, (2, 3))
+    assert not rm.is_bigint()
+    K = sd.sparse_nullspace(rm)
+    assert not isinstance(K, sd.ExactCOO)
+    _assert_kernel_exact(entries, (2, 3), K)
+
+
+def test_nullspace_accepts_coefficients_beyond_int64():
+    """A coefficient whose exact form needs more than 64 bits must not be rejected.
+
+    Genome-scale models carry 15-significant-digit decimals such as -7.73333333333333e-08,
+    whose exact rational has a denominator of 10**22. Clearing denominators across such a row
+    exceeds int64, which scipy sparse cannot store.
+    """
+    tiny = Fraction(-773333333333333, 10**22)
+    entries = [(0, 0, tiny), (0, 1, Fraction(-1)), (0, 2, Fraction(1)),
+               (1, 1, Fraction(1)), (1, 3, Fraction(-1))]
+    rm = sd.RationalMatrix.from_fractions(entries, (2, 4))
+    assert rm.is_bigint()
+    _assert_kernel_exact(entries, (2, 4), sd.sparse_nullspace(rm))
+
+
+def test_nullspace_round_trips_its_own_exact_output():
+    tiny = Fraction(-773333333333333, 10**22)
+    entries = [(0, 0, tiny), (0, 1, Fraction(-1)), (1, 1, Fraction(1)), (1, 2, Fraction(-1))]
+    K = sd.sparse_nullspace(sd.RationalMatrix.from_fractions(entries, (2, 3)))
+    assert isinstance(K, sd.ExactCOO)
+    sd.sparse_nullspace(K)
+
+
+def test_nullspace_keeps_exact_values_from_object_arrays():
+    tiny = Fraction(-773333333333333, 10**22)
+    A = np.empty((2, 3), dtype=object)
+    A[:] = Fraction(0)
+    A[0, 0], A[0, 1] = tiny, Fraction(-1)
+    A[1, 1], A[1, 2] = Fraction(1), Fraction(-1)
+    entries = [(0, 0, tiny), (0, 1, Fraction(-1)), (1, 1, Fraction(1)), (1, 2, Fraction(-1))]
+    _assert_kernel_exact(entries, (2, 3), sd.sparse_nullspace(A))
+
+
+def test_from_fractions_rejects_out_of_range_entries():
+    with pytest.raises(IndexError):
+        sd.RationalMatrix.from_fractions([(0, 5, Fraction(1))], (2, 3))
+
+
+def test_bigint_matrix_reports_unsupported_operations():
+    tiny = Fraction(-773333333333333, 10**22)
+    rm = sd.RationalMatrix.from_fractions([(0, 0, tiny), (0, 1, Fraction(-1))], (1, 2))
+    assert rm.is_bigint()
+    with pytest.raises(NotImplementedError):
+        rm.clone()


### PR DESCRIPTION
Three related fixes. Each is measured; none is a redesign.

---

## 1. Nullspace input could not hold what its output already could

`sparse_nullspace` ratchets on the way **out**: results too large for scipy sparse come back as an `ExactCOO` of arbitrary-precision `Fraction`s. The **input** side had no such ratchet — `from_numpy` and `from_cobra_model` built `csr_matrix(..., dtype=np.int64)` directly, and the function accepted only scipy sparse. A matrix whose exact entries needed more than 64 bits had nowhere to go, and callers hit an `OverflowError` from scipy before any straindesign code ran.

Reachable from ordinary models. `iYS854` carries `-7.73333333333333e-08`, 15 significant digits, so its exact rational has a denominator of `10**22`. Not a small-number problem — neither affected model has a coefficient below `1e-9` — and no rescaling avoids it:

| repair | iYS854 | Chlorella_variabilis_iAJ526 |
|---|---|---|
| divide row by gcd | unchanged, 74 bits | unchanged, 64 bits |
| `limit_denominator(1e6)` | fits, but a coefficient changes by 100% | 209 bits |
| `limit_denominator(1e9)` | 89 bits | 316 bits |
| `limit_denominator(1e12)` | 119 bits | 456 bits |

`Chlorella_variabilis_iAJ526` mixes seven unrelated 15-digit decimals in one row, so the lcm needs over 200 bits by construction. `iAF1260b` is exact and fits at every bound, so this is not general.

**Change.** Both constructors go through `_build_from_sparse_data`, which already picks int64 CSR when values fit and the `Fraction` store when they do not; new `RationalMatrix.from_fractions` for exact input; `_rref_integer_sparse` reads via `_iter_row_fractions` / `_nnz_per_column` instead of touching `_num_sparse`, so either store works. Its arithmetic was already Python integers, so nothing downstream changed. `sparse_nullspace` also accepts the `ExactCOO` it emits. CSR-only operations raise `NotImplementedError` rather than `AttributeError` on `None`.

**No escalation on ordinary input**, which was the main risk:

| | input store | nullspace output | nullspace time (main -> branch) | coupled compression, median of 5 |
|---|---|---|---|---|
| iML1515 | int64 | `csr_matrix` | 0.32 -> 0.33 s | 1.69 -> 1.69 s |
| yeast-GEM | int64 | `ExactCOO` | 0.68 -> 0.67 s | 2.74 -> 2.60 s |

yeast-GEM is the documented ratchet case, and it ratchets on the *output* only, identically on both sides. Compressed sizes are unchanged (1373, 2355).

Both previously-failing models now work: `iYS854` gives a (9648, 5180) kernel in 3.1 s and `Chlorella_variabilis_iAJ526` a (9484, 5309) kernel in 3.0 s, both verified exactly zero over the rationals on 25 sampled columns.

---

## 2. `remove_blocked_reactions` had nothing to remove

It filters on bounds and detects nothing itself, so on a normally-bounded model compression ran on the full network. The structural sweep already in `speedy_fva` proves reactions blocked with no LP; running it before the copy is compressed gives that filter something to remove.

On iML1515 it finds **873 of the 888** a kernel-based propagation finds, in **0.05 s against 1.20 s**, and neither reports a reaction FVA disagrees with.

| model | bound | solver | main | branch | |
|---|---|---|---|---|---|
| iML1515 | ATPM | gurobi | 14.43 s | 10.08 s | **+30.1%** |
| iML1515 | ATPM | glpk | 14.05 s | 10.12 s | +28.0% |
| iML1515 | none | gurobi | 14.67 s | 9.93 s | +32.3% |
| iML1515 | none | glpk | 12.57 s | 10.24 s | +18.5% |
| iJN1463 | ATPM | gurobi | 13.52 s | 9.32 s | +31.1% |
| iJN1463 | ATPM | glpk | 11.82 s | 8.88 s | +24.9% |
| iJN1463 | none | gurobi | 13.37 s | 9.69 s | +27.5% |

LP count 1066 -> 840. Roughly 40% of the gain is cheaper compression rather than fewer LPs.

**Measured side effect:** the pinning shrinks the compressed model, so GLPK lands on slightly different vertices. On iML1515 without the ATPM bound its small disagreements with cobra go from 31 (worst 1.0e-4) to 78 (worst 1.3e-3), on values around 5e-3. Gurobi is unaffected at 31 either way and no reaction changes blocked status.

---

## 3. Phase 1b removed

The `min(sum|x|)` scan resolved bounds Phase 1c then resolved anyway from the same warm LP. Removing it moves wall time by -4.9% to +4.6% across eight configurations and leaves the disagreement count with cobra exactly unchanged on both solvers. The LP it builds is what 1c re-optimizes, so the build stays; only the initial solve goes.

---

## 4. A non-optimal status is no longer reported as an answer

```python
elif status != OPTIMAL:
    res_max[j] = True      # marked resolved
    continue                # ...incumbent never set
```

Feasibility is established once at setup and only the objective changes afterwards, so an individual objective LP cannot be genuinely infeasible. The old code returned whatever partial incumbent happened to be present, silently. It now retries on a fresh LP twice, then reports NaN and warns once with a count and the statuses seen. `UNBOUNDED` was and remains handled separately.

On **iAF1260b** this was returning 853 blocked reactions against Gurobi's and cobra's 834:

| | gurobi | glpk |
|---|---|---|
| main | 834, 0 spurious | **853, 19 spurious** |
| branch | 834, 0 spurious | **834, 0 spurious, 0 NaN** |

The retries recover every one, so no bound is given up. The parallel path's leftover NaNs feed the same warning.

---

`pytest tests/` — 432 passed, 7 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
