### PR TITLE
Stop densifying float sparse input, and fall back when the scaled basis exceeds int64

### DIFF
--- a/straindesign/compression.py
+++ b/straindesign/compression.py
@@ -892,13 +892,25 @@ def sparse_nullspace(matrix):
             den = csr_matrix((np.ones(A.nnz, dtype=np.int64), A.indices.copy(), A.indptr.copy()), shape=A.shape)
             rm = RationalMatrix._from_sparse(num, den)
         else:
-            rm = RationalMatrix.from_numpy(A.toarray())
+            rows, cols, nums, dens = [], [], [], []
+            for r in range(A.shape[0]):
+                for i in range(A.indptr[r], A.indptr[r + 1]):
+                    frac = float_to_fraction(A.data[i])
+                    if frac:
+                        rows.append(r)
+                        cols.append(int(A.indices[i]))
+                        nums.append(frac.numerator)
+                        dens.append(frac.denominator)
+            rm = RationalMatrix._build_from_sparse_data(rows, cols, nums, dens, *A.shape)
     else:
         rm = RationalMatrix.from_numpy(np.asarray(matrix))
     K = nullspace(rm)
     if K.is_bigint():
         return K.to_coo_exact()
-    csr, _ = K.to_sparse_csr()
+    try:
+        csr, _ = K.to_sparse_csr()
+    except OverflowError:
+        return K.to_coo_exact()
     return csr
 
 

--- a/tests/test_07_compression.py
+++ b/tests/test_07_compression.py
@@ -345,3 +345,32 @@ def test_bigint_matrix_reports_unsupported_operations():
     assert rm.is_bigint()
     with pytest.raises(NotImplementedError):
         rm.clone()
+
+
+def test_nullspace_falls_back_when_the_scaled_basis_exceeds_int64():
+    """The return type must follow what can actually be stored, not just the input's store.
+
+    to_sparse_csr scales the basis by a common denominator, and that product can exceed int64
+    even when every individual numerator fits.
+    """
+    from scipy import sparse as sp
+    rng = np.random.default_rng(0)
+    A = sp.random(300, 500, density=0.01, random_state=1, format="csr")
+    A.data = np.round(A.data, 3)
+    K = sd.sparse_nullspace(A)
+    assert isinstance(K, sd.ExactCOO)
+    assert K.shape[0] == 500
+
+
+def test_nullspace_of_float_sparse_matches_the_dense_route():
+    from scipy import sparse as sp
+    from straindesign.compression import RationalMatrix
+    A = sp.random(40, 60, density=0.08, random_state=3, format="csr")
+    A.data = np.round(A.data, 2)
+    viaseq = sd.sparse_nullspace(A)
+    viadense = sd.sparse_nullspace(RationalMatrix.from_numpy(A.toarray()))
+    to_set = lambda K: ({(int(r), int(c), Fraction(int(v), int(K.denom)))
+                         for r, c, v in zip(K.rows, K.cols, K.data)} if isinstance(K, sd.ExactCOO)
+                        else {(int(r), int(c), Fraction(int(v)))
+                              for r, c, v in zip(*[K.tocoo().row, K.tocoo().col, K.tocoo().data])})
+    assert to_set(viaseq) == to_set(viadense)


### PR DESCRIPTION
Two problems in `sparse_nullspace`, both reachable from ordinary use, both found while profiling a caller.

## 1. Float sparse input was densified

```python
else:
    rm = RationalMatrix.from_numpy(A.toarray())
```

`from_numpy` materialises the dense array and loops over **every cell** in Python. On a 9382 x 19249 stoichiometry that is 180 million cells read to recover 27k nonzeros — 30.1 s of a 100 s run, by profile.

Converting the nonzeros directly is O(nnz). The same `float_to_fraction` conversion is applied, so the fractions are unchanged; a test pins the two routes to identical output.

## 2. The return type followed the input's store, not what could be stored

```python
if K.is_bigint():
    return K.to_coo_exact()
csr, _ = K.to_sparse_csr()      # can raise OverflowError
```

`is_bigint()` reports only whether the matrix is held as a dict of Fractions. `to_sparse_csr` additionally scales the basis by a common denominator, and **that product can exceed int64 even when every individual numerator fits** — so scipy raised `OverflowError` out of a function whose docstring promises an `ExactCOO` in exactly that case.

A plain random 300 x 500 sparse matrix with three-decimal entries reproduces it:

```python
A = scipy.sparse.random(300, 500, density=0.01, random_state=1, format="csr")
A.data = np.round(A.data, 3)
sd.sparse_nullspace(A)          # OverflowError before, ExactCOO now
```

It now falls back to the exact export.

## Effect

Together with a caller-side fix (passing an already-computed nullity instead of recomputing the kernel), this takes Kimonu's iAF1260b run from **100.3 s to 66.1 s** with identical output — 4004 balanced complexes, matching the published reference exactly.

Two tests added. `pytest tests/` — 434 passed, 7 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)