### PR TITLE
Keep size-1 MCS out of the shortcut when knock-ins are available

### DIFF
--- a/straindesign/compute_strain_designs.py
+++ b/straindesign/compute_strain_designs.py
@@ -803,6 +803,10 @@ def compute_strain_designs(model: Model, **kwargs: dict) -> SDSolutions:
         # constraints that would settle that. Leave those cases to the MILP.
         if any(c < 0.0 for c in list(cmp_ko_cost.values()) + list(cmp_ki_cost.values())):
             size1_mcs_knockable = set()
+        # Non-essential here can mean "a knock-in covers for it", and a design has no knock-in
+        # unless it pays, so knocking it alone may break the protected region. Leave it to the MILP.
+        if cmp_ki_cost:
+            size1_mcs_knockable = set()
         if size1_mcs_knockable:
             cmp_size1_mcs = [{r: -1} for r in size1_mcs_knockable]
             logging.info('  Found ' + str(len(cmp_size1_mcs)) + ' size-1 MCS via SUPPRESS FVA.')

--- a/tests/test_05_straindesign.py
+++ b/tests/test_05_straindesign.py
@@ -671,3 +671,53 @@ def test_objective_survives_a_suppressed_build(curr_solver, model_gpr):
 
     assert model_objective(bare) == ({'r_bm': 1.0}, 'max')
     assert sd.fba(bare, solver=curr_solver).objective_value == pytest.approx(reference.objective_value)
+
+@pytest.fixture
+def model_ki_protect():
+    """Smallest network where a knock-in is the only way to keep PROTECT feasible.
+
+        R1: -> A    R2: A -> B    R3: B -> C    R4: B ->    R5: A -> C (knock-in)    R6: C ->
+
+    SUPPRESS R4, PROTECT R6. Knocking R4 solves it outright. The other way is to knock R2, which
+    starves B and so stops R4, but that also starves C -- unless the knock-in R5 is added to route
+    A to C directly. Brute-force enumeration over every intervention set of cost <= 3 gives exactly
+    two minimal designs: {R4} and {R2 knocked, R5 added}.
+    """
+    from cobra import Model, Reaction, Metabolite
+    m = Model('ki_protect')
+    A, B, C = (Metabolite(x) for x in 'ABC')
+
+    def rxn(i, stoich):
+        r = Reaction('R%d' % i)
+        r.lower_bound, r.upper_bound = 0.0, 1000.0
+        r.add_metabolites(stoich)
+        return r
+
+    m.add_reactions([rxn(1, {A: 1}), rxn(2, {A: -1, B: 1}), rxn(3, {B: -1, C: 1}),
+                     rxn(4, {B: -1}), rxn(5, {A: -1, C: 1}), rxn(6, {C: -1})])
+    return m
+
+
+@pytest.mark.parametrize('skip_fvas', [False, True])
+@pytest.mark.timeout(60)
+def test_knockin_keeps_protect_feasible(model_ki_protect, skip_fvas):
+    """A knock-in must be taken when PROTECT needs it, and a design that breaks PROTECT must not
+    be reported. Both directions matter: reporting {R2} alone is wrong because R6 cannot carry
+    flux without R5, and it also hides the real design {R2, R5} from the enumeration."""
+    solver = next(s for s in [CPLEX, GUROBI, SCIP, GLPK] if s in sd.avail_solvers)
+    modules = [sd.SDModule(model_ki_protect, PROTECT, constraints=['R6 >= 1']),
+               sd.SDModule(model_ki_protect, SUPPRESS, constraints=['R4 >= 1'])]
+    kwargs = dict(sd_modules=modules,
+                  ko_cost={'R1': 1.0, 'R2': 1.0, 'R3': 1.0, 'R4': 1.0, 'R6': 1.0},
+                  ki_cost={'R5': 1.0}, max_cost=3, max_solutions=inf,
+                  solution_approach='populate', solver=solver, compress=False)
+    if skip_fvas:
+        kwargs['skip_preprocessing_fvas'] = True
+    sols = sd.compute_strain_designs(model_ki_protect, **kwargs).get_reaction_sd()
+    got = {frozenset((k, float(v)) for k, v in d.items() if v != 0) for d in sols}
+    ko_only = frozenset({('R4', -1.0)})
+    ko_plus_ki = frozenset({('R2', -1.0), ('R5', 1.0)})
+    assert ko_only in got, 'the plain knock-out design {R4} is missing'
+    assert ko_plus_ki in got, 'the design that needs the knock-in {R2 KO, R5 KI} is missing'
+    assert got == {ko_only, ko_plus_ki}, \
+        'a design was reported that does not satisfy PROTECT: %s' % sorted(map(sorted, got))


### PR DESCRIPTION
## The problem

The size-1 SUPPRESS-FVA shortcut reports a knockout as a finished design on the evidence that the reaction is not essential for the protected region. That evidence is read off the model as given, which contains every knock-in candidate — but a design has none of them unless it pays. So a reaction can look non-essential *only because a knock-in covers for it*, and knocking it alone then leaves PROTECT infeasible.

There is a second half: the shortcut also pops such a reaction from `ko_cost`, so the design that *does* buy the knock-in never reaches the MILP.

## Reproducer

```
R1: -> A    R2: A -> B    R3: B -> C    R4: B ->    R5: A -> C (knock-in)    R6: C ->
SUPPRESS R4, PROTECT R6; every reaction but R5 is a knockout candidate
```

Brute-force enumeration over all intervention sets of cost <= 3 gives exactly two minimal designs: `{R4}` and `{R2 knocked, R5 added}`.

| | result | |
|---|---|---|
| `SDMILP` alone | `{R4}`, `{R2, R5+}` | correct |
| `compute_strain_designs` (before) | `{R2}`, `{R4}` | `{R2}` cannot satisfy PROTECT; `{R2, R5+}` unreachable |
| `compute_strain_designs` (after) | `{R4}`, `{R2, R5+}` | correct |

`SDMILP` was already right, so the encoding and `z_inverted` are fine — only the preprocessing shortcut was at fault. Setting `skip_preprocessing_fvas=True` also avoided it, which is what isolated the faulty path.

## The change

Two lines, directly under the existing guard that disables the same shortcut for rewarding interventions, and for the same kind of reason. The FVAs are untouched and still run on the full model — the flaw was in what was inferred from them, not in how they were run.

Problems without knock-in candidates are unaffected and keep the shortcut.

## Tests

`test_knockin_keeps_protect_feasible`, parametrised over `skip_preprocessing_fvas`, asserts the exact design set — that the knock-in design is present *and* that nothing PROTECT-violating is reported. It fails on `main` and passes here.

Existing coverage did combine PROTECT with `ki_cost`, but asserted only `len(sols) > 0` plus one known knockout; nothing asserted that a knock-in is ever taken, or that the design set is complete. That is the gap this sat in.

Full suite: 412 passed, 7 skipped (`test_06_multiprocessing` run separately: 17 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RFtof9nZXFvCNoXz19po8C