### PR TITLE
Fetch test models from the host_gifs branch before BiGG

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -147,3 +147,6 @@ profile_compression.py
 compression_benchmark.png
 # perf-test artefacts
 tests/perf_results/
+
+# downloaded test models (see tests/_models.py)
+tests/models/

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+prune tests

--- a/tests/_models.py
+++ b/tests/_models.py
@@ -1,0 +1,66 @@
+"""Model loading for the test suite: GitHub-hosted copy first, BiGG last.
+
+`cobra.io.load_model` downloads from BiGG on every fresh machine (CI runners
+have an empty cache), and that download is fragile: cobra 0.30 requests
+``http://bigg.ucsd.edu`` without following the 301 to https, and BiGG has
+since moved to https://bigg.bio. The models the suite needs are therefore
+kept on this repository's ``host_gifs`` asset branch and downloaded from
+there into ``tests/models`` (git-ignored), which serves as the cache for
+later runs. BiGG itself is only tried for models missing from the branch.
+"""
+
+import gzip
+import io
+import logging
+from pathlib import Path
+
+from cobra.io import read_sbml_model
+
+MODEL_DIR = Path(__file__).resolve().parent / "models"
+ASSET_BRANCH = "https://raw.githubusercontent.com/klamt-lab/straindesign/host_gifs/models/{}.xml.gz"
+BIGG_MIRROR = "https://bigg.ucsd.edu/static/models/{}.xml.gz"
+
+logger = logging.getLogger(__name__)
+
+
+def _model_from_gzip(data: bytes):
+    with gzip.open(io.BytesIO(data), "rt", encoding="utf-8") as handle:
+        return read_sbml_model(io.StringIO(handle.read()))
+
+
+def _download(url: str) -> bytes:
+    import httpx
+    response = httpx.get(url, follow_redirects=True, timeout=120)
+    response.raise_for_status()
+    return response.content
+
+
+def load_test_model(model_id: str):
+    """Return the model `model_id` (a BiGG identifier such as ``e_coli_core``).
+
+    Order: ``tests/models/<id>.xml.gz`` if present, then the ``host_gifs``
+    branch (cached into that directory), then cobra's ``load_model`` (its
+    bundled models such as ``textbook``, then BiGG and BioModels through its
+    own cache), then a redirect-following download from BiGG.
+    """
+    local = MODEL_DIR / f"{model_id}.xml.gz"
+    if local.is_file():
+        return _model_from_gzip(local.read_bytes())
+    errors = []
+    try:
+        data = _download(ASSET_BRANCH.format(model_id))
+        MODEL_DIR.mkdir(exist_ok=True)
+        local.write_bytes(data)
+        return _model_from_gzip(data)
+    except Exception as err:
+        errors.append(f"{ASSET_BRANCH.format(model_id)}: {err}")
+    try:
+        from cobra.io import load_model
+        return load_model(model_id)
+    except Exception as err:  # cobra wraps every network failure in RuntimeError
+        errors.append(f"cobra.io.load_model: {err}")
+    try:
+        return _model_from_gzip(_download(BIGG_MIRROR.format(model_id)))
+    except Exception as err:
+        errors.append(f"{BIGG_MIRROR.format(model_id)}: {err}")
+    raise RuntimeError(f"Model '{model_id}' could not be obtained:\n  " + "\n  ".join(errors))

--- a/tests/test_02_lp_optimization.py
+++ b/tests/test_02_lp_optimization.py
@@ -86,7 +86,7 @@ def test_yield_opt_infeasible(curr_solver, model_small_example):
 # ── FVA implementation correctness (e_coli_core) ─────────────────────
 # Compares speedy_fva (compressed + uncompressed), fva_legacy, and cobra FVA.
 
-from cobra.io import load_model
+from ._models import load_test_model
 from cobra.flux_analysis import flux_variability_analysis as cobra_fva
 from straindesign.lptools import fva, fva_legacy, select_solver
 from straindesign.speedy_fva import speedy_fva
@@ -96,7 +96,7 @@ FVA_TOL = 1e-6
 
 @pytest.fixture(scope="module")
 def ecoli_core():
-    return load_model("e_coli_core")
+    return load_test_model("e_coli_core")
 
 
 @pytest.fixture(scope="module")

--- a/tests/test_07_compression.py
+++ b/tests/test_07_compression.py
@@ -5,7 +5,8 @@ import numpy as np
 import warnings
 from fractions import Fraction
 from os.path import dirname, abspath
-from cobra.io import load_model, read_sbml_model
+from cobra.io import read_sbml_model
+from ._models import load_test_model
 from cobra.flux_analysis import flux_variability_analysis
 from sympy import Rational as SympyRational
 import straindesign as sd
@@ -142,12 +143,12 @@ def test_fba_optimum_recovered_through_map():
     exercises the map itself -- it would catch factors drifting out of step with the column
     scaling applied when a lump is re-expressed in one member's units.
     """
-    base = load_model("e_coli_core")
+    base = load_test_model("e_coli_core")
     biomass = next((r.id for r in base.reactions if 'biomass' in r.id.lower()), None)
     assert biomass, "Could not find biomass reaction"
     ref = sd.fba(base, obj={biomass: 1}, obj_sense='maximize').objective_value
 
-    model = load_model("e_coli_core")
+    model = load_test_model("e_coli_core")
     cmp_maps = nt.compress_model(model)
     cmp_id, factor = _trace_lump(cmp_maps, biomass)
     assert cmp_id in [r.id for r in model.reactions], (f"compression map names {cmp_id}, which is not in the compressed model")
@@ -163,13 +164,13 @@ def test_cobra_optimize_after_compression():
     Uses the compression map to back-transform the compressed biomass flux and
     verify it matches the original uncompressed value.
     """
-    model_orig = load_model("e_coli_core")
+    model_orig = load_test_model("e_coli_core")
     biomass_id = next((r.id for r in model_orig.reactions if 'biomass' in r.id.lower()), None)
     assert biomass_id is not None, "Could not find biomass reaction"
     model_orig.objective = biomass_id
     val_orig = model_orig.optimize().objective_value
 
-    model_cmp = load_model("e_coli_core")
+    model_cmp = load_test_model("e_coli_core")
     cmp_map = nt.compress_model(model_cmp)
 
     # Find biomass in compressed model via compression map
@@ -196,11 +197,11 @@ def test_cobra_optimize_after_compression():
 
 def test_fva_expansion():
     """Compression map correctly back-maps FVA results to the original reaction space."""
-    model_orig = load_model("e_coli_core")
+    model_orig = load_test_model("e_coli_core")
     original_ids = [r.id for r in model_orig.reactions]
     fva_orig = flux_variability_analysis(model_orig, fraction_of_optimum=0.0, processes=1)
 
-    model_cmp = load_model("e_coli_core")
+    model_cmp = load_test_model("e_coli_core")
     cmp_map = nt.compress_model(model_cmp)
     fva_cmp = flux_variability_analysis(model_cmp, fraction_of_optimum=0.0, processes=1)
 
@@ -247,7 +248,7 @@ def test_mcs_e_coli_core():
     if not strong_solvers:
         pytest.skip("test_mcs_e_coli_core requires Gurobi, CPLEX, or SCIP (GLPK gives incorrect results)")
     solver = SCIP if SCIP in strong_solvers else next(iter(strong_solvers))
-    model = load_model('e_coli_core')
+    model = load_test_model('e_coli_core')
     modules = [sd.SDModule(model, SUPPRESS, constraints='BIOMASS_Ecoli_core_w_GAM >= 0.001')]
     sols = sd.compute_strain_designs(
         model,

--- a/tests/test_08_gene_ko.py
+++ b/tests/test_08_gene_ko.py
@@ -1,13 +1,13 @@
 """Test gene knockout simulation via gene_kos_to_constraints and resolve_gene_constraints."""
 import pytest
-from cobra.io import load_model
+from ._models import load_test_model
 import straindesign as sd
 from straindesign.networktools import gene_kos_to_constraints, resolve_gene_constraints
 
 
 @pytest.fixture(scope="module")
 def ecoli_core():
-    return load_model('textbook')
+    return load_test_model('textbook')
 
 
 @pytest.fixture(scope="module")

--- a/tests/test_09_performance.py
+++ b/tests/test_09_performance.py
@@ -68,7 +68,8 @@ from numpy import inf
 
 warnings.filterwarnings("ignore")
 
-from cobra.io import read_sbml_model, load_model
+from cobra.io import read_sbml_model
+from ._models import load_test_model
 import straindesign as sd
 from straindesign.names import *
 
@@ -135,7 +136,7 @@ STRONG_SOLVERS = [s for s in [CPLEX, GUROBI] if s in sd.avail_solvers]
 
 @pytest.fixture(scope="session")
 def model_core():
-    return load_model("e_coli_core")
+    return load_test_model("e_coli_core")
 
 
 @pytest.fixture(scope="session")
@@ -399,7 +400,7 @@ def test_iml1515_mcs_393(solver):
     Only run with --large (takes several minutes per solver).
     """
     try:
-        m = load_model("iML1515")
+        m = load_test_model("iML1515")
     except Exception:
         pytest.skip("iML1515 not available in this COBRApy installation")
     t0 = time.perf_counter()

--- a/tests/test_12_save_load_embed_model.py
+++ b/tests/test_12_save_load_embed_model.py
@@ -5,7 +5,8 @@ import sys
 import pickle
 from math import inf
 import pytest
-from cobra.io import load_model, read_sbml_model
+from cobra.io import read_sbml_model
+from ._models import load_test_model
 import straindesign as sd
 import straindesign.compute_strain_designs  # noqa: F401  (ensure submodule imported)
 # `straindesign.compute_strain_designs` the attribute is the *function* (star-
@@ -20,7 +21,7 @@ TOL = 1e-6
 
 @pytest.fixture(scope="module")
 def model():
-    return load_model("textbook")
+    return load_test_model("textbook")
 
 
 def _solver():


### PR DESCRIPTION
cobra.io.load_model fetches http://bigg.ucsd.edu, which now answers 301 to https, and cobra does not follow it; every CI matrix cell failed on the e_coli_core fixture. BiGG has also moved to bigg.bio. The models the suite needs (e_coli_core, iML1515) are hosted on the host_gifs asset branch, so the code history stays free of binaries; tests/_models.py downloads them from there into the git-ignored tests/models directory and reads that copy on later runs. cobra's loader and a redirect- following BiGG download remain as fallbacks. MANIFEST.in prunes tests/ from the sdist, which shipped the test modules without their fixtures or data; the wheel never contained them.